### PR TITLE
Feature/ol 9304 add firewall overrides to vnic in tacp instance

### DIFF
--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -239,6 +239,157 @@ class VnetResource(Resource):
         return self.api.delete_vnet_using_delete(uuid)
 
 
+class StoragePoolResource(ApiResource):
+
+    model = tacp.FlashPoolsApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_flash_pools_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_flash_pools_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_flash_pool_using_get(uuid)
+
+
+class DatacenterResource(ApiResource):
+
+    model = tacp.DatacentersApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_datacenters_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_datacenters_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_datacenter_using_get(uuid)
+
+
+class UserResource(ApiResource):
+
+    model = tacp.UsersApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_users_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_users_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_user_using_get(uuid)
+
+
+class SiteResource(ApiResource):
+
+    model = tacp.LocationsApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_locations_for_organization_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_locations_for_organization_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_location_information_using_get(uuid)
+
+
+class TemplateResource(ApiResource):
+
+    model = tacp.TemplatesApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_templates_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_templates_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_template_using_get(uuid)
+
+
+class TagResource(ApiResource):
+
+    model = tacp.TagsApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_tags_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_tags_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_tag_using_get(uuid)
+
+
+class MigrationZoneResource(ApiResource):
+
+    model = tacp.MigrationZonesApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_migration_zones_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_migration_zones_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_migration_zone_using_get(uuid)
+
+
+class MarketplaceTemplateResource(ApiResource):
+
+    model = tacp.MarketplaceTemplatesApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_marketplace_templates_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_marketplace_templates_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_marketplace_template_using_get(uuid)
+
+
+class ApplicationGroupResource(ApiResource):
+
+    model = tacp.ApplicationGroupsApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_application_group_list_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_application_group_list_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_application_group_information_using_get(uuid)
+
+
+class CategoryResource(ApiResource):
+
+    model = tacp.CategoriesApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_categories_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_categories_using_get()
+
+    def _get_by_uuid(self, uuid):
+        return self._api.get_category_using_get(uuid)
+
+
+class FirewallProfileResource(ApiResource):
+
+    model = tacp.FirewallProfilesApi
+
+    def _get_all(self, *args, **kwargs):
+        if kwargs:
+            return self._api.get_firewall_profiles_using_get(filters=";".join(kwargs))
+        else:
+            return self._api.get_firewall_profiles_using_get()
+
+
 def get_component_fields_by_name(name, component,
                                  api_client, fields=['name', 'uuid']):
     """

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -35,7 +35,7 @@ def wait_to_complete(method):
     @wraps(method)
     def wrapper(self, *a, **kws):
         wait = kws.pop('_wait', True)
-        wait_timeout = kws.pop('_wait_timeout', 60)
+        wait_timeout = kws.pop('_wait_timeout', 120)
 
         method_api_response = method.__get__(self, type(self))(*a, **kws)
 

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -37,12 +37,12 @@ def wait_to_complete(method):
         wait = kws.pop('_wait', True)
         wait_timeout = kws.pop('_wait_timeout', 60)
 
-        methodapi_response = method.__get__(self, type(self))(*a, **kws)
+        method_api_response = method.__get__(self, type(self))(*a, **kws)
 
         if not wait:
-            return methodapi_response
+            return method_api_response
 
-        action_uuid = getattr(methodapi_response, 'action_uuid', None)
+        action_uuid = getattr(method_api_response, 'action_uuid', None)
 
         if action_uuid:
             api_instance = tacp.ActionsApi(self.api_client)
@@ -52,7 +52,7 @@ def wait_to_complete(method):
             while time_spent < wait_timeout:
                 api_response = api_instance.get_action_using_get(action_uuid)
                 if api_response.status == 'Completed':
-                    return methodapi_response
+                    return method_api_response
 
                 sleep(1)
                 time_spent += 1

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -45,7 +45,7 @@ def wait_to_complete(method):
         action_uuid = getattr(method_api_response, 'action_uuid', None)
 
         if action_uuid:
-            api_instance = tacp.ActionsApi(self.api_client)
+            api_instance = tacp.ActionsApi(self._api_client)
 
             time_spent = 0
 
@@ -67,7 +67,7 @@ class Resource(object):
     def __init__(self, client):
         assert self.resource_class is not None
         self.api = self.resource_class(client)
-        self.api_client = client
+        self._api_client = client
 
     FILTER_OPERATORS = [
         '==', '!=', '=lt=', '<', '=le=', '<=', '=gt=', '>', '=ge=', '>=',

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -148,10 +148,13 @@ class Resource(object):
 class ApplicationResource(Resource):
     resource_class = tacp.ApplicationsApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_applications_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_applications_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in
+                    results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_application_using_get(uuid).to_dict()
@@ -185,10 +188,13 @@ class ApplicationResource(Resource):
 class VlanResource(Resource):
     resource_class = tacp.VlansApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_vlans_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_vlans_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in
+                    results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_vlan_using_get(uuid).to_dict()
@@ -205,10 +211,13 @@ class VlanResource(Resource):
 class VnetResource(Resource):
     resource_class = tacp.VnetsApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_vnets_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_vnets_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in
+                    results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_vnet_using_get(uuid).to_dict()
@@ -226,10 +235,12 @@ class StoragePoolResource(Resource):
 
     resource_class = tacp.FlashPoolsApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_flash_pools_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_flash_pools_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_flash_pool_using_get(uuid).to_dict()
@@ -239,10 +250,12 @@ class DatacenterResource(Resource):
 
     resource_class = tacp.DatacentersApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_datacenters_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_datacenters_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_datacenter_using_get(uuid).to_dict()
@@ -252,10 +265,12 @@ class UserResource(Resource):
 
     resource_class = tacp.UsersApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_users_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_users_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_user_using_get(uuid).to_dict()
@@ -265,10 +280,12 @@ class SiteResource(Resource):
 
     resource_class = tacp.LocationsApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_locations_for_organization_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_locations_for_organization_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_location_information_using_get(uuid).to_dict()
@@ -278,10 +295,12 @@ class TemplateResource(Resource):
 
     resource_class = tacp.TemplatesApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_templates_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_templates_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_template_using_get(uuid).to_dict()
@@ -291,10 +310,12 @@ class TagResource(Resource):
 
     resource_class = tacp.TagsApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_tags_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_tags_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_tag_using_get(uuid).to_dict()
@@ -304,10 +325,12 @@ class MigrationZoneResource(Resource):
 
     resource_class = tacp.MigrationZonesApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_migration_zones_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_migration_zones_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_migration_zone_using_get(uuid).to_dict()
@@ -317,10 +340,12 @@ class MarketplaceTemplateResource(Resource):
 
     resource_class = tacp.MarketplaceTemplatesApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_marketplace_templates_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_marketplace_templates_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_marketplace_template_using_get(uuid).to_dict()
@@ -330,10 +355,12 @@ class ApplicationGroupResource(Resource):
 
     resource_class = tacp.ApplicationGroupsApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_application_group_list_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_application_group_list_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_application_group_information_using_get(uuid).to_dict()
@@ -343,10 +370,12 @@ class CategoryResource(Resource):
 
     resource_class = tacp.CategoriesApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_categories_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_categories_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
     def get_by_uuid(self, uuid):
         return self.api.get_category_using_get(uuid).to_dict()
@@ -356,10 +385,12 @@ class FirewallProfileResource(Resource):
 
     resource_class = tacp.FirewallProfilesApi
 
-    def filter(self, **filters):
-        return [result.to_dict() for result in
-                self.api.get_firewall_profiles_using_get(
-                    **self.get_filters_kws(**filters))]
+    def filter(self, as_dict=False, **filters):
+        results = self.api.get_firewall_profiles_using_get(
+            **self.get_filters_kws(**filters))
+        if as_dict:
+            return [result.to_dict() for result in results]
+        return results
 
 
 def get_component_fields_by_name(name, component,

--- a/lib/ansible/modules/tacp/tacp_info.py
+++ b/lib/ansible/modules/tacp/tacp_info.py
@@ -21,7 +21,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: tacp_instance
+module: tacp_info
 
 short_description: This is my test module
 
@@ -156,7 +156,7 @@ def run_module():
 
     resource = resource_dict[module.params['resource']](api_client)
 
-    all_resources = resource.get_all()
+    all_resources = resource.filter()
 
     if module.params['resource'] == 'migration_zone':
         for resource in all_resources:
@@ -177,6 +177,8 @@ def run_module():
                     for datacenter in resource['allocations']['datacenters']:
                         datacenter['name'] = datacenterResource.get_by_uuid(datacenter['datacenter_uuid'])[
                             'name']
+    
+
     result[module.params['resource']] = all_resources
     
 

--- a/lib/ansible/modules/tacp/tacp_info.py
+++ b/lib/ansible/modules/tacp/tacp_info.py
@@ -177,7 +177,25 @@ def run_module():
                     for datacenter in resource['allocations']['datacenters']:
                         datacenter['name'] = datacenterResource.get_by_uuid(datacenter['datacenter_uuid'])[
                             'name']
-    
+    elif module.params['resource'] == 'datacenter':
+        for resource in all_resources:
+            if 'networks' in resource:
+                vnetResource = tacp_utils.VnetResource(api_client)
+                vlanResource = tacp_utils.VlanResource(api_client)
+                for network in resource['networks']:
+                    try:
+                        network['name'] = vnetResource.get_by_uuid(network['uuid'])['name']
+                        network['network_type'] = 'vnet'
+
+                    except Exception:
+                        network['name'] = vlanResource.get_by_uuid(network['uuid'])[
+                            'name']
+                        network['network_type'] = 'vlan'
+                        
+            if 'tags' in resource:
+                tagResource = tacp_utils.TagResource(api_client)
+                for tag in resource['tags']:
+                    tag['name'] = tagResource.get_by_uuid(tag['uuid'])['name']
 
     result[module.params['resource']] = all_resources
     

--- a/lib/ansible/modules/tacp/tacp_info.py
+++ b/lib/ansible/modules/tacp/tacp_info.py
@@ -156,7 +156,17 @@ def run_module():
 
     resource = resource_dict[module.params['resource']](api_client)
 
-    result[module.params['resource']] = resource.get_all()
+    all_resources = resource.get_all()
+
+    if module.params['resource'] == 'migration_zone':
+        for resource in all_resources:
+            if 'applications' in resource:
+                applicationResource = tacp_utils.ApplicationResource(api_client)
+                for application in resource['applications']:
+                    application['name'] = applicationResource.get_by_uuid(application['uuid'])['name']
+
+    result[module.params['resource']] = all_resources
+    
 
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results

--- a/lib/ansible/modules/tacp/tacp_info.py
+++ b/lib/ansible/modules/tacp/tacp_info.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2020, Lenovo
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.tacp_ansible import tacp_utils
+
+
+import json
+import tacp
+import sys
+from tacp.rest import ApiException
+from pprint import pprint
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: tacp_instance
+
+short_description: This is my test module
+
+version_added: "2.9"
+
+description:
+    - "This is my longer description explaining my test module"
+
+options:
+    name:
+        description:
+            - This is the message to send to the test module
+        required: true
+    new:
+        description:
+            - Control to demo if the result of this module is changed or not
+        required: false
+
+extends_documentation_fragment:
+    - tacp
+
+author:
+    - Xander Madsen (@xmadsen)
+'''
+
+EXAMPLES = '''
+# Pass in a message
+- name: Test with a message
+  tacp_instance:
+    name: hello world
+
+# pass in a message and have changed true
+- name: Test with a message and changed output
+  tacp_instance:
+    name: hello world
+    new: true
+
+# fail the module
+- name: Test failure of the module
+  tacp_instance:
+    name: fail me
+'''
+
+RETURN = '''
+original_message:
+    description: The original name param that was passed in
+    type: str
+    returned: always
+message:
+    description: The output message that the test module generates
+    type: str
+    returned: always
+'''
+
+
+def run_module():
+    # define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        api_key=dict(type='str', required=True),
+        resource=dict(type='str', required=True,
+                      choices=[
+                          "application",
+                          "application_group",
+                          "category",
+                          "datacenter",
+                          "firewall_profile",
+                          "marketplace_template",
+                          "migration_zone",
+                          "site",
+                          "storage_pool",
+                          "tag",
+                          "template",
+                          "user",
+                          "vlan",
+                          "vnet"])
+    )
+
+    # seed the result dict in the object
+    # we primarily care about changed and state
+    # change is if this module effectively modified the target
+    # state will include any data that you want your module to pass back
+    # for consumption, for example, in a subsequent task
+    result = dict(
+        changed=False,
+        args=[]
+    )
+
+    # the AnsibleModule object will be our abstraction working with Ansible
+    # this includes instantiation, a couple of common attr would be the
+    # args/params passed to the execution, as well as if the module
+    # supports check mode
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    # if the user is working with this module in only check mode we do not
+    # want to make any changes to the environment, just return the current
+    # state with no modifications
+    if module.check_mode:
+        module.exit_json(**result)
+
+    def fail_with_reason(reason):
+        result['msg'] = reason
+        module.fail_json(**result)
+
+    # Return the inputs for debugging purposes
+    result['args'] = module.params
+
+    # Define configuration
+    configuration = tacp.Configuration()
+    configuration.host = "https://manage.cp.lenovo.com"
+    configuration.api_key_prefix['Authorization'] = 'Bearer'
+    configuration.api_key['Authorization'] = module.params['api_key']
+    api_client = tacp.ApiClient(configuration)
+
+    resource_dict = {"application": tacp_utils.ApplicationResource,
+                     "application_group": tacp_utils.ApplicationGroupResource,
+                     "category": tacp_utils.CategoryResource,
+                     "datacenter": tacp_utils.DatacenterResource,
+                     "firewall_profile": tacp_utils.FirewallProfileResource,
+                     "marketplace_template": tacp_utils.MarketplaceTemplateResource,
+                     "migration_zone": tacp_utils.MigrationZoneResource,
+                     "site": tacp_utils.SiteResource,
+                     "storage_pool": tacp_utils.StoragePoolResource,
+                     "tag": tacp_utils.TagResource,
+                     "template": tacp_utils.TemplateResource,
+                     "user": tacp_utils.UserResource,
+                     "vlan": tacp_utils.VlanResource,
+                     "vnet": tacp_utils.VnetResource
+                     }
+
+    resource = resource_dict[module.params['resource']](api_client)
+
+    result[module.params['resource']] = resource.get_all()
+
+    # in the event of a successful module execution, you will want to
+    # simple AnsibleModule.exit_json(), passing the key/value results
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/tacp/tacp_info.py
+++ b/lib/ansible/modules/tacp/tacp_info.py
@@ -164,7 +164,19 @@ def run_module():
                 applicationResource = tacp_utils.ApplicationResource(api_client)
                 for application in resource['applications']:
                     application['name'] = applicationResource.get_by_uuid(application['uuid'])['name']
-
+            if 'allocations' in resource:
+                if 'categories' in resource['allocations']:
+                    categoryResource = tacp_utils.CategoryResource(
+                        api_client)
+                    for category in resource['allocations']['categories']:
+                        category['name'] = categoryResource.get_by_uuid(category['category_uuid'])[
+                        'name']
+                if 'datacenters' in resource['allocations']:
+                    datacenterResource = tacp_utils.DatacenterResource(
+                        api_client)
+                    for datacenter in resource['allocations']['datacenters']:
+                        datacenter['name'] = datacenterResource.get_by_uuid(datacenter['datacenter_uuid'])[
+                            'name']
     result[module.params['resource']] = all_resources
     
 

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -179,6 +179,11 @@ def run_module():
 
             mac_address = nic.get('mac_address')
             automatic_mac_address = not bool(mac_address)
+            if 'firewall_override' in nic:
+                firewall_override_uuid = tacp_utils.get_component_fields_by_name(
+                    nic['firewall_override'], 'firewall_override', api_client)
+            else:
+                firewall_override_uuid = None
 
             if i == 0:
                 for boot_order_item in boot_order:
@@ -193,6 +198,7 @@ def run_module():
                 vnic_payload = tacp.ApiAddVnicPayload(
                     automatic_mac_address=automatic_mac_address,
                     name=vnic_name,
+                    firewall_override_uuid=firewall_override_uuid,
                     network_uuid=network_uuid,
                     boot_order=vnic_boot_order,
                     mac_address=mac_address
@@ -202,6 +208,7 @@ def run_module():
             network_payload = tacp.ApiCreateOrEditApplicationNetworkOptionsPayload(
                 name=vnic_name,
                 automatic_mac_assignment=automatic_mac_address,
+                firewall_override_uuid=firewall_override_uuid,
                 network_uuid=network_uuid,
                 vnic_uuid=vnic_uuid,
                 mac_address=mac_address

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -12,6 +12,7 @@ from ansible.module_utils.tacp_ansible.tacp_constants import State, Action
 import json
 import tacp
 import sys
+from uuid import uuid4
 from tacp.rest import ApiException
 from pprint import pprint
 


### PR DESCRIPTION
##### SUMMARY
This PR adds the ability to provide a firewall_override parameter to a vNic parameter when creating a VM in tacp_instance. 


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tacp_instance

##### ADDITIONAL INFORMATION

```yaml
---
- name: test my new module
  hosts: localhost
  tasks:
  - name: Create a VM on TACP
    tacp_instance:
      api_key: <API_KEY>
      name: AnsibleTest_VM2
      state: shutdown
      datacenter: VDC-AnsibleDev
      migration_zone: r0S3-MC-MZ
      template: CentOS 7.5 (64-bit) - Lenovo Template
      storage_pool: R5Beta-SP0
      vcpu_cores: 1
      memory: 2g
      disks:
        - size_gb: 20
      nics:
        - name: vNIC 0
          type: VNET
          network: VNET-TEST
          firewall_override: ANSIBLE-Allow-All
    register: testout

  - name: Output
    debug:
      msg: '{{ testout }}'
```

```bash
venv) ~/W/ansible.lenovo-tacp ❯❯❯ ansible-playbook test_playbooks/create_vm.yml


PLAY [test my new module] ***********************************************************************************************************************************************************

TASK [Create a VM on TACP] **********************************************************************************************************************************************************
changed: [localhost]

TASK [Output] ***********************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "ansible_module_results": {
            "application_group_uuid": null,
            "auto_snapshot_policy": null,
            "boot_order": [
                {
                    "disk_uuid": "2066853b-1919-4db4-b04b-788278302574",
                    "name": "Disk 0",
                    "order": 1,
                    "vnic_uuid": null
                },
                {
                    "disk_uuid": null,
                    "name": "vNIC 0",
                    "order": 2,
                    "vnic_uuid": "52c7eeed-826b-4b93-867f-10938c4d1545"
                }
            ],
            "category_uuid": null,
            "datacenter_uuid": "89182aac-8457-4a78-b7b5-e42565de5afc",
            "description": null,
            "disaster_recovery_policy": null,
            "disks": [
                {
                    "bandwidth_limit": null,
                    "iops_limit": null,
                    "name": "Disk 0",
                    "size": 53687091200,
                    "uuid": "2066853b-1919-4db4-b04b-788278302574"
                }
            ],
            "flash_pool_uuid": "c08e01e6-4e21-40e0-9e74-a812058f412d",
            "hardware_assisted_virtualization_enabled": true,
            "host_uuid": null,
            "memory": 2147483648,
            "migration_zone_uuid": "8db9218e-6b92-4c9e-b8cf-270c9ef8509d",
            "name": "AnsibleTest_VM2",
            "network_service_app_vnet_uuids": [],
            "status": "Shut down",
            "tags": [],
            "template_uuid": "ee81814e-e0df-4182-819e-b0e12dc5e984",
            "uuid": "0ec7c77d-ad68-44fe-8c57-b887a5095cc1",
            "vcpus": 1,
            "vm_mode": "Enhanced",
            "vnics": [
                {
                    "ip_address": null,
                    "mac_address": "b4:d1:35:00:07:7f",
                    "networks": [
                        {
                            "firewall_profile_uuid": null,
                            "network_name": "VNET-TEST",
                            "network_uuid": "bd3f62a4-1914-45e5-ba01-603ca16f7ea8"
                        }
                    ],
                    "type": "VNET",
                    "uuid": "52c7eeed-826b-4b93-867f-10938c4d1545"
                }
            ]
PLAY RECAP **************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```