### PR TITLE
Feature/OL-9822 enable custom boot order, multiple vNICs, multiple disks in tacp_instance module

### DIFF
--- a/lib/ansible/module_utils/tacp_ansible/tacp_constants.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_constants.py
@@ -17,3 +17,8 @@ class PlaybookState:
     PAUSED = "paused"
     ABSENT = "absent"
     RESUMED = "resumed"
+
+    @classmethod
+    def _all(cls):
+        return [getattr(cls, attr) for attr in dir(cls)
+                if not attr.startswith('_')]

--- a/lib/ansible/module_utils/tacp_ansible/tacp_constants.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_constants.py
@@ -1,4 +1,4 @@
-class State:
+class API_State:
     RUNNING = "Running"
     SHUTDOWN = "Shut down"
     PAUSED = "Paused"
@@ -8,7 +8,7 @@ class State:
     DELETING = "Deleting"
 
 
-class Action:
+class Playbook_State:
     STARTED = "started"
     SHUTDOWN = "shutdown"
     STOPPED = "stopped"

--- a/lib/ansible/module_utils/tacp_ansible/tacp_constants.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_constants.py
@@ -1,4 +1,4 @@
-class API_State:
+class ApiState:
     RUNNING = "Running"
     SHUTDOWN = "Shut down"
     PAUSED = "Paused"
@@ -8,7 +8,7 @@ class API_State:
     DELETING = "Deleting"
 
 
-class Playbook_State:
+class PlaybookState:
     STARTED = "started"
     SHUTDOWN = "shutdown"
     STOPPED = "stopped"

--- a/lib/ansible/module_utils/tacp_ansible/tacp_exceptions.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_exceptions.py
@@ -12,3 +12,35 @@ class InvalidPowerActionException(Exception):
 
 class UuidNotFoundException(Exception):
     pass
+
+
+class InvalidNetworkNameException(Exception):
+    pass
+
+
+class InvalidNetworkTypeException(Exception):
+    pass
+
+
+class InvalidVnicNameException(Exception):
+    pass
+
+
+class InvalidFirewallOverrideNameException(Exception):
+    pass
+
+
+class InvalidDiskBandwidthLimitException(Exception):
+    pass
+
+
+class InvalidDiskIopsLimitException(Exception):
+    pass
+
+
+class InvalidDiskSizeException(Exception):
+    pass
+
+
+class InvalidDiskNameException(Exception):
+    pass

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -140,10 +140,10 @@ class Resource(object):
             return {'filters': query_string}
         return {}
 
-    def get_uuid_by_name(self, name):
+    def get_by_name(self, name):
         instances = self.filter(name=name)
         if instances:
-            return instances[0].uuid
+            return instances[0]
         return None
 
     filter_method = None
@@ -211,7 +211,7 @@ class ApplicationResource(Resource):
         return power_action_dict[power_action](uuid)
 
 
-class UpdateApplicationResource(Resource):
+class ApplicationUpdateResource(Resource):
 
     resource_class = tacp.EditApplicationsApi
 
@@ -229,23 +229,27 @@ class UpdateApplicationResource(Resource):
     @wait_to_complete
     def edit_disk_name(self, disk_uuid, uuid, disk_name):
         body = tacp.ApiDiskSizePayload(name=disk_name, uuid=disk_uuid)
-        return self.api.edit_application_disk_name_using_put(body, disk_uuid, uuid)  # noqa
+        return self.api.edit_application_disk_name_using_put(
+            body, disk_uuid, uuid)
 
     @wait_to_complete
     def edit_disk_size(self, disk_uuid, uuid, disk_size):
         body = tacp.ApiDiskSizePayload(size=disk_size, uuid=disk_uuid)
-        return self.api.edit_application_disk_size_using_put(body, disk_uuid, uuid)  # noqa
+        return self.api.edit_application_disk_size_using_put(
+            body, disk_uuid, uuid)
 
     @wait_to_complete
-    def edit_disk_bw_limit(self, disk_uuid, uuid, bw_limit):  # noqa
+    def edit_disk_bw_limit(self, disk_uuid, uuid, bw_limit):
         body = tacp.ApiDiskBandwidthPayload(
             bandwidth_limit=bw_limit, uuid=disk_uuid)
-        return self.api.edit_application_disk_bandwidth_limit_using_put(body, disk_uuid, uuid)  # noqa
+        return self.api.edit_application_disk_bandwidth_limit_using_put(
+            body, disk_uuid, uuid)
 
     @wait_to_complete
-    def edit_disk_iops_limit(self, disk_uuid, uuid, iops_limit):  # noqa
+    def edit_disk_iops_limit(self, disk_uuid, uuid, iops_limit):
         body = tacp.ApiDiskIopsPayload(iops_limit=iops_limit, uuid=disk_uuid)
-        return self.api.edit_application_disk_iops_limit_using_put(body, disk_uuid, uuid)  # noqa
+        return self.api.edit_application_disk_iops_limit_using_put(
+            body, disk_uuid, uuid)
 
 
 class VlanResource(Resource):
@@ -292,6 +296,18 @@ class DatacenterResource(Resource):
 
     filter_method = "get_datacenters_using_get"
     uuid_method = "get_datacenter_using_get"
+
+    def get_firewall_override_by_name(self, datacenter_uuid,
+                                      firewall_override_name):
+        firewall_overrides = self.api.get_datacenter_firewall_overrides_using_get(  # noqa
+            uuid=datacenter_uuid,
+            filters='name=="{}"'.format(firewall_override_name))
+        firewall_override = None
+
+        if firewall_overrides:
+            firewall_override = firewall_overrides[0]
+
+        return firewall_override
 
 
 class UserResource(Resource):
@@ -378,7 +394,8 @@ def get_component_fields_by_name(name, component,
 
     valid_components = ["storage_pool", "application",
                         "template", "datacenter", "migration_zone",
-                        "vnet", "vlan", "firewall_profile", "firewall_override"]  # noqa
+                        "vnet", "vlan", "firewall_profile",
+                        "firewall_override"]
 
     if component not in valid_components:
         return "Invalid component"
@@ -530,9 +547,9 @@ def fill_in_missing_names_by_uuid(item, api_resource, key_name):
         uuid_name = 'category_uuid'
     else:
         uuid_name = key_name[:-1] + "_uuid"
-    uuids = [resource[uuid_name] for resource in item[key_name]]  # noqa
-    resource_list = {resource.uuid: resource.name for resource in  # noqa
-                        api_resource.filter(uuid=('=in=', *uuids))}  # noqa
+    uuids = [resource[uuid_name] for resource in item[key_name]]
+    resource_list = {resource.uuid: resource.name for resource in
+                     api_resource.filter(uuid=('=in=', *uuids))}
     for resource in item[key_name]:
         resource['name'] = resource_list[resource[uuid_name]]
 

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -124,9 +124,8 @@ class Resource(object):
                                     'Allowed: {}'.format(op, allowed))
 
                 if op in ('=in=', '=out='):
-                    if len(value) > 0:
-                        value = ','.join(map(str, value))
-                        value = '({})'.format(value)
+                    value = ','.join(map(str, value))
+                    value = '({})'.format(value)
                 else:
                     value = value[0]
             else:

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -72,7 +72,6 @@ def wait_to_complete(method):
                 sleep(1)
                 time_spent += 1
             raise ActionTimedOutException
-        raise InvalidActionUuidException
     return wrapper
 
 
@@ -332,6 +331,19 @@ class FirewallProfileResource(Resource):
     resource_class = tacp.FirewallProfilesApi
 
     filter_method = "get_firewall_profiles_using_get"
+
+
+class EditApplicationResource(Resource):
+
+    resource_class = tacp.EditApplicationsApi
+
+    @wait_to_complete
+    def create_disk_for_application(self, body, uuid):
+        return self.api.create_application_disk_using_post(body, uuid)
+
+    @wait_to_complete
+    def create_vnic_for_application(self, body, uuid):
+        return self.api.create_application_vnic_using_post(body, uuid)
 
 
 def get_component_fields_by_name(name, component,

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -6,7 +6,6 @@
 import json
 import re
 import tacp
-import sys
 
 try:
     from urllib.parse import quote

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -8,6 +8,11 @@ import re
 import tacp
 import sys
 
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
+
 from functools import wraps
 
 from tacp.rest import ApiException
@@ -130,8 +135,8 @@ class Resource(object):
                     value = value[0]
             else:
                 op = '=='
-                value = v
-            filters.append('{}{}{}'.format(k, op, value))
+                value = quote(v)
+            filters.append('{}{}"{}"'.format(k, op, value))
 
         return ';'.join(filters)
 

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -15,7 +15,7 @@ from ansible.module_utils.tacp_ansible.tacp_exceptions import (
     ActionTimedOutException, InvalidActionUuidException,
     InvalidPowerActionException, UuidNotFoundException
 )
-from ansible.module_utils.tacp_ansible.tacp_constants import Playbook_State
+from ansible.module_utils.tacp_ansible.tacp_constants import PlaybookState
 from time import sleep
 
 

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -345,6 +345,35 @@ class EditApplicationResource(Resource):
     def create_vnic_for_application(self, body, uuid):
         return self.api.create_application_vnic_using_post(body, uuid)
 
+    @wait_to_complete
+    def edit_boot_order_for_application(self, body, uuid):
+        return self.api.edit_application_boot_order_using_put(body, uuid)
+
+    @wait_to_complete
+    def edit_disk_name_for_application(self, disk_uuid, uuid, disk_name=None):
+        if disk_name:
+            body = tacp.ApiDiskSizePayload(name=disk_name, uuid=disk_uuid)
+            return self.api.edit_application_disk_name_using_put(body, disk_uuid, uuid)  # noqa
+
+    @wait_to_complete
+    def edit_disk_size_for_application(self, disk_uuid, uuid, disk_size=None):
+        if disk_size:
+            body = tacp.ApiDiskSizePayload(size=disk_size, uuid=disk_uuid)
+            return self.api.edit_application_disk_size_using_put(body, disk_uuid, uuid)  # noqa
+
+    @wait_to_complete
+    def edit_disk_bw_limit_for_application(self, disk_uuid, uuid, bw_limit=None):  # noqa
+        if bw_limit:
+            body = tacp.ApiDiskBandwidthPayload(
+                bandwidth_limit=bw_limit, uuid=disk_uuid)
+            return self.api.edit_application_disk_bandwidth_limit_using_put(body, disk_uuid, uuid)  # noqa
+
+    @wait_to_complete
+    def edit_disk_iops_limit_for_application(self, disk_uuid, uuid, iops_limit=None):  # noqa
+        if iops_limit:
+            body = tacp.ApiDiskIopsPayload(iops_limit=iops_limit, uuid=disk_uuid)  # noqa
+            return self.api.edit_application_disk_iops_limit_using_put(body, disk_uuid, uuid)  # noqa
+
 
 def get_component_fields_by_name(name, component,
                                  api_client, fields=['name', 'uuid']):

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -197,14 +197,14 @@ class ApplicationResource(Resource):
             specified by UUID
         """
         power_action_dict = {
-            Playbook_State.STARTED: self.api.start_application_using_put,
-            Playbook_State.SHUTDOWN: self.api.shutdown_application_using_put,
-            Playbook_State.STOPPED: self.api.stop_application_using_put,
-            Playbook_State.RESTARTED: self.api.restart_application_using_put,
-            Playbook_State.FORCE_RESTARTED: self.api.force_restart_application_using_put,  # noqa
-            Playbook_State.PAUSED: self.api.pause_application_using_put,
-            Playbook_State.ABSENT: self.api.delete_application_using_delete,
-            Playbook_State.RESUMED: self.api.resume_application_using_put
+            PlaybookState.STARTED: self.api.start_application_using_put,
+            PlaybookState.SHUTDOWN: self.api.shutdown_application_using_put,
+            PlaybookState.STOPPED: self.api.stop_application_using_put,
+            PlaybookState.RESTARTED: self.api.restart_application_using_put,
+            PlaybookState.FORCE_RESTARTED: self.api.force_restart_application_using_put,  # noqa
+            PlaybookState.PAUSED: self.api.pause_application_using_put,
+            PlaybookState.ABSENT: self.api.delete_application_using_delete,
+            PlaybookState.RESUMED: self.api.resume_application_using_put
         }
         if power_action not in power_action_dict:
             raise InvalidPowerActionException
@@ -223,7 +223,6 @@ class UpdateApplicationResource(Resource):
     def create_vnic(self, body, uuid):
         return self.api.create_application_vnic_using_post(body, uuid)
 
-    @wait_to_complete
     def edit_boot_order(self, body, uuid):
         return self.api.edit_application_boot_order_using_put(body, uuid)
 

--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -7,11 +7,6 @@ import json
 import re
 import tacp
 
-try:
-    from urllib.parse import quote
-except ImportError:
-    from urllib import quote
-
 from functools import wraps
 
 from tacp.rest import ApiException
@@ -71,6 +66,7 @@ def wait_to_complete(method):
                 sleep(1)
                 time_spent += 1
             raise ActionTimedOutException
+        raise InvalidActionUuidException
     return wrapper
 
 

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -408,10 +408,6 @@ def run_module():
                                                           uuid=instance_uuid)  # noqa
 
         for vnic in module.params['nics']:
-
-            if vnic['name'] in [instance_vnic.name for instance_vnic
-                                in instance.boot_order if instance_vnic.vnic_uuid]:  # noqa
-                continue
             vnic_uuid = [boot_order_vnic.vnic_uuid for boot_order_vnic in
                          boot_order if boot_order_vnic.name == vnic['name']][0]
             name = vnic['name']

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -351,13 +351,6 @@ def instance_power_action(instance, action):
     RESULT['changed'] = True
 
 
-def get_template_for_instance(instance):
-    template_uuid = instance.template_uuid
-    template = RESOURCES['template'].get_by_uuid(template_uuid)
-
-    return template
-
-
 def update_instance_state(instance, current_state, target_state):
     if current_state in [ApiState.RUNNING,
                          ApiState.SHUTDOWN,
@@ -378,7 +371,8 @@ def add_playbook_vnics(playbook_vnics, instance):
         instance (ApiApplicationInstancePropertiesPayload): A payload
             containing the properties of the instance
     """
-    playbook_template = get_template_for_instance(instance)
+    playbook_template = RESOURCES['template'].get_by_uuid(
+        instance.template_uuid)
     template_boot_order = playbook_template.boot_order
 
     template_vnics = [
@@ -542,7 +536,8 @@ def add_playbook_disks(playbook_disks, instance):
         instance (ApiApplicationInstancePropertiesPayload): A payload
             containing the properties of the instance
     """
-    playbook_template = get_template_for_instance(instance)
+    playbook_template = RESOURCES['template'].get_by_uuid(
+        instance.template_uuid)
     template_boot_order = playbook_template.boot_order
 
     template_disks = [

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -89,29 +89,6 @@ STATE_ACTIONS = [Action.STARTED, Action.SHUTDOWN, Action.STOPPED,
 
 def run_module():
     # define available arguments/parameters a user can pass to the module
-<<<<<<< HEAD
-    module_args = dict(
-        api_key=dict(type='str', required=True),
-        portal_url=dict(type='str', required=False,
-                        default="https://manage.cp.lenovo.com"),
-        name=dict(type='str', required=True),
-        state=dict(type='str', required=True,
-                   choices=STATE_ACTIONS),
-        datacenter=dict(type='str', required=False),
-        migration_zone=dict(type='str', required=False),
-        storage_pool=dict(type='str', required=False),
-        template=dict(type='str', required=False),
-        vcpu_cores=dict(type='int', required=False),
-        memory=dict(type='str', required=False),
-        disks=dict(type='list', required=False),
-        nics=dict(type='list', required=False),
-        vtx_enabled=dict(type='bool', default=True, required=False),
-        auto_recovery_enabled=dict(type='bool', default=True, required=False),
-        description=dict(type='str', required=False),
-        vm_mode=dict(type='str', default='Enhanced', choices=['enhanced', 'Enhanced',
-                                                              'compatibility', 'Compatibility']),
-        application_group={
-=======
     module_args = {
         "api_key": {'type': 'str', 'required': True},
         "portal_url": {'type': 'str', 'required': False,
@@ -136,7 +113,6 @@ def run_module():
                     'choices': ['enhanced', 'Enhanced',
                                 'compatibility', 'Compatibility']},
         "application_group": {
->>>>>>> 2da364a8e4... OL-9822 Convert dict() syntax to {} for module_args and result declarations
             'type': 'str',
             'required': False,
         },
@@ -160,10 +136,6 @@ def run_module():
         result['msg'] = reason
         module.fail_json(**result)
 
-<<<<<<< HEAD
-    # manipulate or modify the state as needed (this is going to be the
-    # part where your module will do what it needs to do)
-=======
     def get_boot_order(module, template_dict):
 
         # Get boot devices uuids and order from the template
@@ -222,7 +194,6 @@ def run_module():
             instance_boot_order[order - 1] = payload
         # sys.stdout.write(str(instance_boot_order))
         return instance_boot_order
->>>>>>> 2da364a8e4... OL-9822 Convert dict() syntax to {} for module_args and result declarations
 
     def generate_instance_params(module):
         # VM does not exist yet, so we must create it
@@ -234,13 +205,8 @@ def run_module():
             component_uuid = tacp_utils.get_component_fields_by_name(
                 module.params[component], component, api_client)
             if not component_uuid:
-<<<<<<< HEAD
-                reason = "%s %s does not exist, cannot continue." % component.capitalize(
-                ) % module.params[component]
-=======
                 reason = "{} {} does not exist, cannot continue.".format(
                     component.capitalize(), module.params[component])
->>>>>>> 2da364a8e4... OL-9822 Convert dict() syntax to {} for module_args and result declarations
                 fail_with_reason(reason)
             instance_params['{}_uuid'.format(component)] = component_uuid
 

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -4,37 +4,13 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from ansible.module_utils.tacp_ansible.tacp_exceptions import (
-<<<<<<< HEAD
     ActionTimedOutException, InvalidActionUuidException
 )
-from ansible.module_utils.tacp_ansible.tacp_constants import State, Action
-
-
-import json
-import tacp
-<<<<<<< HEAD
-import sys
-from time import sleep
-=======
-
->>>>>>> f84617e268... OL-9822  Remove sys import and stdout.write debug lines
-from uuid import uuid4
-=======
-    ActionTimedOutException, InvalidActionUuidException)
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> 0648ccf6c0... OL-9822 Do some major refactoring - don't push this yet
-=======
-from ansible.module_utils.tacp_ansible.tacp_constants import Action, State
-=======
 from ansible.module_utils.tacp_ansible.tacp_constants import (
     Playbook_State, API_State)
->>>>>>> 51394307ce... OL-9822 Everything working as expected now, refactor completed, need to rebase with devel.
+
 from ansible.module_utils.tacp_ansible import tacp_utils
 from ansible.module_utils.basic import AnsibleModule
-
-import json
->>>>>>> 5febb4e0fc... OL-9822 Perform major refactoring, run_module is now very concise, most functionality has been broken out into small functions, constants taken outside the run_module scope
 from tacp.rest import ApiException
 import tacp
 from uuid import uuid4
@@ -533,98 +509,9 @@ def get_add_network_payload(vnic_payload, vnic_uuid):
     return network_payload
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        network_payloads = []
-        vnic_payloads = []
-        vlan_resource = tacp_utils.VlanResource(api_client)
-        vnet_resource = tacp_utils.VnetResource(api_client)
-        for nic in module.params['nics']:
-
-            vnic_uuids = [device.vnic_uuid for device in boot_order if
-                          (device.vnic_uuid and
-                           device.name == nic['name'])]
-            if not vnic_uuids:
-                # The vnic is not in the template, so move on
-                continue
-            vnic_uuid = vnic_uuids[0]
-
-            if nic['type'].lower() == 'vlan':
-                network_uuid = vlan_resource.filter(
-                    name=("==", nic['network']))[0].uuid
-            else:
-                network_uuid = vnet_resource.filter(
-                    name=("==", nic['network']))[0].uuid
-
-            mac_address = nic.get('mac_address')
-            automatic_mac_address = not bool(mac_address)
-            name = nic['name']
-
-            network_payload = tacp.ApiCreateOrEditApplicationNetworkOptionsPayload(  # noqa
-                name=name,
-                automatic_mac_assignment=automatic_mac_address,
-                firewall_override_uuid=firewall_override_uuid,
-                network_uuid=network_uuid,
-                vnic_uuid=vnic_uuid,
-                mac_address=mac_address
-            )
-            network_payloads.append(network_payload)
-
-        instance_params['boot_order'] = boot_order
-        instance_params['networks'] = network_payloads
-        instance_params['vnics'] = vnic_payloads
-        instance_params['vcpus'] = module.params['vcpu_cores']
-        instance_params['memory'] = tacp_utils.convert_memory_abbreviation_to_bytes(  # noqa
-            module.params['memory'])
-        instance_params['vm_mode'] = module.params['vm_mode'].capitalize()
-        instance_params['vtx_enabled'] = module.params['vtx_enabled']
-        instance_params['auto_recovery_enabled'] = module.params['auto_recovery_enabled']  # noqa
-        instance_params['description'] = module.params['description']
-
-        if module.params['application_group']:
-            ag_resource = tacp_utils.ApplicationGroupResource(api_client)
-            uuid = ag_resource.get_uuid_by_name(
-                module.params['application_group']
-            )
-            if uuid is None:
-                resp = ag_resource.create(module.params['application_group'],
-                                          instance_params['datacenter_uuid'])
-                uuid = resp.object_uuid
-
-            instance_params['application_group_uuid'] = uuid
-
-        return instance_params
-
-    def create_instance(instance_params, api_client):
-        application_resource = tacp_utils.ApplicationResource(api_client)
-
-        body = tacp.ApiCreateApplicationPayload(
-            name=instance_params['instance_name'],
-            datacenter_uuid=instance_params['datacenter_uuid'],
-            flash_pool_uuid=instance_params['storage_pool_uuid'],
-            migration_zone_uuid=instance_params['migration_zone_uuid'],
-            template_uuid=instance_params['template_uuid'],
-            vcpus=instance_params['vcpus'],
-            memory=instance_params['memory'],
-            vm_mode=instance_params['vm_mode'],
-            networks=instance_params['networks'],
-            vnics=instance_params['vnics'],
-            boot_order=instance_params['boot_order'],
-            hardware_assisted_virtualization_enabled=instance_params['vtx_enabled'],  # noqa
-            enable_automatic_recovery=instance_params['auto_recovery_enabled'],
-            description=instance_params['description'],
-            application_group_uuid=instance_params.get(
-                'application_group_uuid')
-        )
-=======
-def add_vnic_to_instance(network_payload):
-    """Adds a vNIC to an instance if a vNIC with the same name is not already
-        present in that instance.
-=======
 def add_playbook_disks(playbook_disks, instance_uuid):
     playbook_template = get_template_for_instance(instance_uuid)
     template_boot_order = playbook_template.boot_order
->>>>>>> 5febb4e0fc... OL-9822 Perform major refactoring, run_module is now very concise, most functionality has been broken out into small functions, constants taken outside the run_module scope
 
     template_disks = [
         device.name for device in template_boot_order if device.disk_uuid]
@@ -707,93 +594,8 @@ def get_full_boot_order_payload_for_playbook(playbook_instance):
         new_boot_order_entry = get_new_boot_order_entry_for_device(
             boot_device, playbook_devices)
 
-<<<<<<< HEAD
-    # Make sure all disks and nics have a boot_order assigned
-    if not all([bool(device.get('boot_order')) for device in
-                module.params['disks'] + module.params['nics']]):
-        fail_with_reason(
-            'All disks and NICs must have a boot_order specified, starting with 1.')  # noqa
-
-    playbook_devices = [dev for dev in module.params['disks']
-                        + module.params['nics']]
-    disks_and_nics_names = [dev['name'] for dev in playbook_devices]
-
-    # Make sure that all template boot devices are present
-    #  in disks_and_nics_names
-    if not all([template_device in disks_and_nics_names for
-                template_device in template_boot_device_names]):
-        fail_with_reason('All devices for template {} must be present in disks and nics fields: [{}]'.format(  # noqa
-            template_dict['name'], ', '.join(template_boot_device_names)))
-
-    # initialize the boot order with blank entries times the
-    # number of disks + nics
-    instance_boot_order = [None] * len(disks_and_nics_names)
-
-    # Now set the boot device into the correct order by the index provided
-    for boot_device in playbook_devices:
-        if boot_device['name'] in template_boot_device_names:
-            order = boot_device['boot_order']
-            boot_device_dict = [device for device
-                                in template_boot_order
-                                if boot_device['name'] == device['name']][0]  # noqa
-            disk_uuid = boot_device_dict['disk_uuid']
-            name = boot_device_dict['name']
-            vnic_uuid = boot_device_dict['vnic_uuid']
-        else:
-            if boot_device in [disk['name'] for disk in module.params['disks']]:  # noqa
-                disk_uuid = str(uuid4())
-                vnic_uuid = None
-            else:
-                disk_uuid = None
-                vnic_uuid = str(uuid4())
-            name = boot_device['name']
-            order = boot_device['boot_order']
-        payload = tacp.ApiBootOrderPayload(disk_uuid=disk_uuid,
-                                           name=name,
-                                           order=order,
-                                           vnic_uuid=vnic_uuid)
-        instance_boot_order[order - 1] = payload
-
-    return instance_boot_order
-
-
-def create_new_application_instance_payload(playbook_instance):
-    # VM does not exist yet, so we must create it
-    instance_params = {}
-    instance_params['instance_name'] = module.params['name']
-
-    components = ['storage_pool', 'datacenter', 'migration_zone']
-    for component in components:
-        component_uuid = tacp_utils.get_component_fields_by_name(
-            module.params[component], component, API_CLIENT)
-        if not component_uuid:
-            reason = '{} {} does not exist, cannot continue.'.format(
-                component.capitalize(), module.params[component])
-            fail_with_reason(reason)
-        instance_params['{}_uuid'.format(component)] = component_uuid
->>>>>>> 0648ccf6c0... OL-9822 Do some major refactoring - don't push this yet
-
-    # Check if template exists, it must in order to continue
-    template_results = TEMPLATE_RESOURCE.filter(
-        name=playbook_instance['template'])
-
-    # There should only be one template returned if it exists
-    template_dict = template_results[0].to_dict()
-
-    template_uuid = template_dict.get('uuid')
-
-    if template_uuid:
-        instance_params['template_uuid'] = template_uuid
-        template_boot_order = template_results[0].boot_order
-    else:
-        # Template does not exist - must fail the task
-        reason = 'Template %s does not exist, cannot continue.' % module.params[  # noqa
-            'template']
-        fail_with_reason(reason)
-=======
         boot_order_payload = get_boot_order_payload(new_boot_order_entry)
         new_boot_order.append(boot_order_payload)
->>>>>>> 5febb4e0fc... OL-9822 Perform major refactoring, run_module is now very concise, most functionality has been broken out into small functions, constants taken outside the run_module scope
 
     new_boot_order = sorted(new_boot_order, key=lambda payload: payload.order)
     full_boot_order_payload = tacp.ApiEditApplicationPayload(

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -243,8 +243,8 @@ def get_parameters_to_create_new_application(playbook_instance):
         data['application_group_uuid'] = uuid
 
     network_payloads = []
-    template_vnics = [boot_device for boot_device
-                      in template_boot_order if boot_device.vnic_uuid]
+    template_vnics = [boot_device for boot_device in template_boot_order
+                      if boot_device.vnic_uuid]
 
     playbook_vnics_in_template = {
         playbook_vnic['name']: template_vnic
@@ -263,7 +263,7 @@ def get_parameters_to_create_new_application(playbook_instance):
         template_order = template_vnic.order
 
         parameters_to_create_new_vnic = get_parameters_to_create_vnic(
-            datacenter_uuid=data['datacenter_uuid'],  # noqa
+            datacenter_uuid=data['datacenter_uuid'],
             playbook_vnic=playbook_vnic,
             template_order=template_order
         )

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -13,8 +13,12 @@ from ansible.module_utils.tacp_ansible.tacp_constants import State, Action
 
 import json
 import tacp
+<<<<<<< HEAD
 import sys
 from time import sleep
+=======
+
+>>>>>>> f84617e268... OL-9822  Remove sys import and stdout.write debug lines
 from uuid import uuid4
 from tacp.rest import ApiException
 from pprint import pprint
@@ -142,7 +146,6 @@ def run_module():
         # Get boot devices uuids and order from the template
         template_boot_order = template_dict['boot_order']
 
-        # sys.stdout.write(str(boot_order_dict))
         template_boot_device_names = [boot_device['name'] for
                                       boot_device in template_boot_order]
 
@@ -162,8 +165,6 @@ def run_module():
                     template_device in template_boot_device_names]):
             fail_with_reason("All devices for template {} must be present in disks and nics fields: [{}]".format(  # noqa
                 template_dict['name'], ', '.join(template_boot_device_names)))
-
-        # sys.stdout.write(str(disks_and_nics_names))
 
         # initialize the boot order with blank entries times the
         # number of disks + nics
@@ -193,7 +194,7 @@ def run_module():
                                                order=order,
                                                vnic_uuid=vnic_uuid)
             instance_boot_order[order - 1] = payload
-        # sys.stdout.write(str(instance_boot_order))
+
         return instance_boot_order
 
     def generate_instance_params(module):
@@ -289,7 +290,6 @@ def run_module():
 
             instance_params['application_group_uuid'] = uuid
 
-        # sys.stdout.write(str(instance_params))
         return instance_params
 
     def create_instance(instance_params, api_client):

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -408,6 +408,10 @@ def run_module():
                                                           uuid=instance_uuid)  # noqa
 
         for vnic in module.params['nics']:
+            if vnic['name'] in [instance_nic.name for instance_nic
+                                in instance.nics]:
+                # This nic was already configured, skip it
+                continue
             vnic_uuid = [boot_order_vnic.vnic_uuid for boot_order_vnic in
                          boot_order if boot_order_vnic.name == vnic['name']][0]
             name = vnic['name']

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -239,10 +239,10 @@ def get_parameters_to_create_new_application(playbook_instance):
                       in template_boot_order if boot_device.vnic_uuid]
 
     for playbook_vnic in playbook_instance['nics']:
-        if playbook_vnic['name'] in [vnic.name for vnic in template_vnics]:  # noqa
-            corresponding_template_vnic = [vnic for vnic in
-                                            template_vnics if
-                                            vnic.name == playbook_vnic['name']][0]  # noqa
+        if playbook_vnic['name'] in [vnic.name for vnic in template_vnics]:
+            corresponding_template_vnic = next(vnic for vnic in
+                                               template_vnics if
+                                               vnic.name == playbook_vnic['name'])  # noqa
 
             vnic_uuid = corresponding_template_vnic.vnic_uuid
             template_order = corresponding_template_vnic.order
@@ -352,9 +352,12 @@ def instance_exists(instance_name):
 
 def get_template_for_instance(instance):
     template_uuid = instance.template_uuid
-    template = RESOURCES['template'].filter(uuid=template_uuid)[0]
+    template_result = RESOURCES['template'].filter(uuid=template_uuid)
+    if template_result:
+        template = template_result[0]
+        return template
 
-    return template
+    return None
 
 
 def update_instance_state(instance, current_state, target_state):
@@ -760,7 +763,7 @@ def run_module():
 
     if not instance_exists(instance_name):
         instance_payload = create_instance(playbook_instance)
-        
+
         instance = get_instance_by_name(instance_name)
 
         add_playbook_vnics(playbook_instance['nics'], instance)

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -6,7 +6,7 @@
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible.module_utils.tacp_ansible.tacp_constants import (
-    Playbook_State, API_State)
+    PlaybookState, ApiState)
 from ansible.module_utils.tacp_ansible import tacp_exceptions
 from ansible.module_utils.tacp_ansible import tacp_utils
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request adds the ability to create a VM with arbitrary quantities/configurations of disks and vNICs, as well as setting a custom boot order. 

The general approach is to create a VM from the specified template with the default virtual hardware resources, then go through the playbook's disks and nics fields to add the nondefault ones after the fact before performing any potential power actions on the VM and returning a success.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tacp_instance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: test my new module
  hosts: localhost
  tasks:
  - name: Create a VM on TACP with multiple disks, multiple NICs, and a custom boot order
    tacp_instance:
      api_key: <API_KEY>
      name: ANSIBLE_TestVM-Xander
      state: shutdown
      datacenter: VDC-AnsibleDev
      migration_zone: r0S3-MC-MZ
      template: CentOS 7.5 (64-bit) - Lenovo Template
      storage_pool: R0S3-SP0
      vcpu_cores: 1
      memory: 2g
      disks:
        - name: Disk 0
          size_gb: 80
          boot_order: 2
        - name: Disk 1
          size_gb: 1
          boot_order: 3
          iops_limit: 50
        - name: Disk 2
          size_gb: 2
          boot_order: 4
          bandwidth_limit: 5000000
      nics:
        - name: vNIC 0
          type: VNET
          network: VNET-TEST
          boot_order: 1
        - name: vNIC 1
          type: VNET
          network: VNET-TEST
          boot_order: 5
          firewall_override: ANSIBLE-Allow-All
```
