### PR TITLE
Feature/OL-10489 add documentation to tacp modules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,28 +31,20 @@ Download this git respository.
 
 |
 
-Find the ``modules/`` and ``module_utils/`` directories in your existing 
-Ansible environment. The following 
+The tacp modules and module_utils files can be added to any of the following dfirectories:
 
-``[user@hostname ansible.lenovo-tacp]# pip3 show ansible | grep Location``
+- any directory added to the ``ANSIBLE_LIBRARY`` environment variable (``$ANSIBLE_LIBRARY`` takes a colon-separated list like ``$PATH``)
 
-``Location: /usr/local/lib/python3.6/site-packages``
+- ``~/.ansible/plugins/``
 
-|
+- ``/usr/share/ansible/plugins/``
 
-In this example, the ansible directory is located at ``/usr/local/lib/python3.6/site-packages/ansible`` .
-
-|
-
-In your environment, you should replace instances of ``/usr/local/lib/python3.6/site-packages/`` with the directory returned in the previous command's output.
-
-|
 
 Copy the ``module_utils/tacp_ansible/`` directory from this ansible.lenovo-tacp repo into
 the local ansible installation's ``module_utils/`` directory.
 
 ``[user@hostname ansible.lenovo-tacp]# cp -R ./lib/ansible/module_utils/tacp_ansible 
-/usr/local/lib/python3.6/site-packages/ansible/module_utils``
+/usr/share/ansible/plugins/module_utils``
 
 |
 
@@ -60,7 +52,7 @@ Copy the ``modules/tacp/`` directory from this ansible.lenovo-tacp repo into
 the local ansible installation's ``modules/cloud/`` directory.
 
 ``[user@hostname ansible.lenovo-tacp]# cp -R ./lib/ansible/modules/tacp 
-/usr/local/lib/python3.6/site-packages/ansible/modules/cloud``
+/usr/share/ansible/plugins/modules/cloud``
 
 Examples
 ========

--- a/README.rst
+++ b/README.rst
@@ -37,22 +37,39 @@ The tacp modules and module_utils files can be added to any of the following dfi
 
 - ``~/.ansible/plugins/``
 
-- ``/usr/share/ansible/plugins/``
-
-
-Copy the ``module_utils/tacp_ansible/`` directory from this ansible.lenovo-tacp repo into
-the local ansible installation's ``module_utils/`` directory. In this example the module files are copied to the ``/usr/share/ansible/plugins`` location, which requires ``sudo``.
-
-``[user@hostname ansible.lenovo-tacp]# sudo cp -R ./lib/ansible/module_utils/tacp_ansible 
-/usr/share/ansible/plugins/module_utils``
+- On CentOS/RHEL systems, ``/usr/share/ansible/plugins/``
 
 |
 
-Copy the ``modules/tacp/`` directory from this ansible.lenovo-tacp repo into
-the local ansible installation's ``modules/cloud/`` directory.
+1. For example, create the ``~/.ansible/plugins/`` directory:
+
+``[user@hostname ansible.lenovo-tacp]# mkdir -p ~/.ansible/plugins/``
+
+2. Copy the ``module_utils/tacp_ansible/`` directory from this ansible.lenovo-tacp repo into
+   the local ansible installation's ``module_utils/`` directory. In this example the module files 
+   are copied to the ``/usr/share/ansible/plugins`` location, which requires ``sudo``.
+
+``[user@hostname ansible.lenovo-tacp]# sudo cp -R ./lib/ansible/module_utils/tacp_ansible 
+~/.ansible/plugins/module_utils``
+
+3. Copy the ``modules/tacp/`` directory from this ansible.lenovo-tacp repo into
+   the local ansible installation's ``modules/cloud/`` directory.
 
 ``[user@hostname ansible.lenovo-tacp]# sudo cp -R ./lib/ansible/modules/tacp 
-/usr/share/ansible/plugins/modules/cloud``
+~/.ansible/plugins/modules/cloud``
+
+4. Verify the manual installation worked:
+
+.. code-block:: shell 
+
+  [user@hostname ansible.lenovo-tacp]# ansible-doc -t module tacp_instance
+  > TACP_INSTANCE    (/home/user/.ansible/plugins/modules/cloud/tacp/tacp_instance.py)
+
+        This module can be used to create new application instances on the ThinkAgile CP cloud platform, as well as delete and modify power states of existing application instances. Currently this module cannot modify the resources of
+        existing application instances aside from performing deletion and power state operations.
+        .
+        .
+        .
 
 Examples
 ========

--- a/README.rst
+++ b/README.rst
@@ -1,93 +1,326 @@
-|PyPI version| |Docs badge| |Chat badge| |Build Status| |Code Of Conduct| |Mailing Lists| |License|
+*****************************
+ThinkAgile CP Ansible Modules
+*****************************
 
-*******
-Ansible
-*******
+This repository contains Lenovo-created Ansible modules
+for automating workflows with the ThinkAgile CP composable cloud platform.
 
-Ansible is a radically simple IT automation system. It handles
-configuration management, application deployment, cloud provisioning,
-ad-hoc task execution, network automation, and multi-node orchestration. Ansible makes complex
-changes like zero-downtime rolling updates with load balancers easy. More information on `the Ansible website <https://ansible.com/>`_.
+Getting Started
+===============
+The following instructions will show you how to download and install the
+tacp_info, tacp_instance, and tacp_network modules into your existing 
+Ansible environment.
 
-Design Principles
-=================
+Requirements
+------------
+- Python >= 3.6
+- python3-pip
+- ansible
+- tacp
 
-*  Have a dead simple setup process and a minimal learning curve.
-*  Manage machines very quickly and in parallel.
-*  Avoid custom-agents and additional open ports, be agentless by
-   leveraging the existing SSH daemon.
-*  Describe infrastructure in a language that is both machine and human
-   friendly.
-*  Focus on security and easy auditability/review/rewriting of content.
-*  Manage new remote machines instantly, without bootstrapping any
-   software.
-*  Allow module development in any dynamic language, not just Python.
-*  Be usable as non-root.
-*  Be the easiest IT automation system to use, ever.
 
-Use Ansible
-===========
+Installation
+------------
+Download this git respository.
 
-You can install a released version of Ansible via ``pip``, a package manager, or
-our `release repository <https://releases.ansible.com/ansible/>`_. See our
-`installation guide <https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html>`_ for details on installing Ansible
-on a variety of platforms.
+``cd ~``
 
-Red Hat offers supported builds of `Ansible Engine <https://www.ansible.com/ansible-engine>`_.
+``git clone https://github.com/lenovo/ansible.lenovo-tacp.git``
 
-Power users and developers can run the ``devel`` branch, which has the latest
-features and fixes, directly. Although it is reasonably stable, you are more likely to encounter
-breaking changes when running the ``devel`` branch. We recommend getting involved
-in the Ansible community if you want to run the ``devel`` branch.
+``cd ./ansible.lenovo-tacp``
 
-Get Involved
-============
+|
 
-*  Read `Community
-   Information <https://docs.ansible.com/ansible/latest/community>`_ for all
-   kinds of ways to contribute to and interact with the project,
-   including mailing list information and how to submit bug reports and
-   code to Ansible.
-*  Join a `Working Group
-   <https://github.com/ansible/community/wiki>`_, an organized community devoted to a specific technology domain or platform.
-*  Submit a proposed code update through a pull request to the ``devel`` branch.
-*  Talk to us before making larger changes
-   to avoid duplicate efforts. This not only helps everyone
-   know what is going on, it also helps save time and effort if we decide
-   some changes are needed.
-*  For a list of email lists, IRC channels and Working Groups, see the
-   `Communication page <https://docs.ansible.com/ansible/latest/community/communication.html>`_
+Find the ``modules/`` and ``module_utils/`` directories in your existing 
+Ansible environment. The following 
 
-Coding Guidelines
-=================
+``[user@hostname ansible.lenovo-tacp]# pip3 show ansible | grep Location``
 
-We document our Coding Guidelines in the `Developer Guide <https://docs.ansible.com/ansible/devel/dev_guide/>`_. We particularly suggest you review:
+``Location: /usr/local/lib/python3.6/site-packages``
 
-* `Contributing your module to Ansible <https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_checklist.html>`_
-* `Conventions, tips and pitfalls <https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_best_practices.html>`_
+|
 
-Branch Info
-===========
+In this example, the ansible directory is located at ``/usr/local/lib/python3.6/site-packages/ansible`` .
 
-*  The ``devel`` branch corresponds to the release actively under development.
-*  The ``stable-2.X`` branches correspond to stable releases.
-*  Create a branch based on ``devel`` and set up a `dev environment <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#common-environment-setup>`_ if you want to open a PR.
-*  See the `Ansible release and maintenance <https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html>`_ page for information about active branches.
+|
 
-Roadmap
-=======
+In your environment, you should replace instances of ``/usr/local/lib/python3.6/site-packages/`` with the directory returned in the previous command's output.
 
-Based on team and community feedback, an initial roadmap will be published for a major or minor version (ex: 2.7, 2.8).
-The `Ansible Roadmap page <https://docs.ansible.com/ansible/devel/roadmap/>`_ details what is planned and how to influence the roadmap.
+|
+
+Copy the ``module_utils/tacp_ansible/`` directory from this ansible.lenovo-tacp repo into
+the local ansible installation's ``module_utils/`` directory.
+
+``[user@hostname ansible.lenovo-tacp]# cp -R ./lib/ansible/module_utils/tacp_ansible 
+/usr/local/lib/python3.6/site-packages/ansible/module_utils``
+
+|
+
+Copy the ``modules/tacp/`` directory from this ansible.lenovo-tacp repo into
+the local ansible installation's ``modules/cloud/`` directory.
+
+``[user@hostname ansible.lenovo-tacp]# cp -R ./lib/ansible/modules/tacp 
+/usr/local/lib/python3.6/site-packages/ansible/modules/cloud``
+
+Examples
+========
+
+**tacp_info**
+
+.. code-block:: yaml
+
+   ---
+   - name: Test tacp_info Ansible module for ThinkAgile CP
+     hosts: localhost
+     gather_facts: false
+     tasks:
+     - name: Get details about application instances from ThinkAgile CP
+       tacp_info:
+         api_key: "{{ api_key}}"
+         resource: instance
+
+     - name: Get details about datacenters and networks from ThinkAgile CP
+       tacp_info:
+         api_key: "{{ api_key}}"
+         resource: "{{ resource }}"
+      loop:
+         - datacenter
+         - vlan
+         - vnet
+      loop_control:
+         loop_var: resource
+
+      - name: Get a list of the available marketplace application templates from
+            ThinkAgile CP
+        tacp_info:
+          api_key: "{{ api_key}}"
+          resource: marketplace_template
+
+**tacp_instance**
+
+.. code-block:: yaml
+
+   ---
+   - name: Test tacp_instance Ansible module for ThinkAgile CP
+     hosts: localhost
+     gather_facts: false
+     tasks:
+      - name: Create a basic VM on ThinkAgile CP
+        tacp_instance:
+          api_key: "{{ api_key }}"
+          name: Basic_VM1
+          state: started
+          datacenter: Datacenter1
+          migration_zone: Zone1
+          template: CentOS 7.5 (64-bit) - Lenovo Template
+          storage_pool: Pool1
+          vcpu_cores: 1
+          memory: 4096GB
+          disks:
+          - name: Disk 0
+            size_gb: 50
+            boot_order: 1
+          nics:
+          - name: vNIC 0
+            type: VNET
+            network: VNET-TEST
+            boot_order: 2
+
+      - name: Create a shutdown VM with multiple disks and set its NIC to the first 
+            boot device
+        tacp_instance:
+          api_key: "{{ api_key }}"
+          name: Basic_VM2
+          state: started
+          datacenter: Datacenter1
+          migration_zone: Zone1
+          template: RHEL 7.4 (Minimal) - Lenovo Template
+          storage_pool: Pool1
+          vcpu_cores: 1
+          memory: 8G
+          disks:
+            - name: Disk 0
+              size_gb: 50
+              boot_order: 2
+            - name: Disk 1
+              size_gb: 200
+              boot_order: 3
+          nics:
+            - name: vNIC 0
+              type: VLAN
+              network: VLAN-300
+              boot_order: 1
+
+      - name: Create a VM with multiple disks with limits, and two NICs with static
+            MAC addresses, and don't power it on after creation
+        tacp_instance:
+          api_key: "{{ api_key }}"
+          name: Basic_VM3
+          state: shutdown
+          datacenter: Datacenter1
+          migration_zone: Zone1
+          template: RHEL 7.4 (Minimal) - Lenovo Template
+          storage_pool: Pool1
+          vcpu_cores: 1
+          memory: 8GB
+          disks:
+            - name: Disk 0
+              size_gb: 50
+              boot_order: 2
+              iops_limit: 200
+            - name: Disk 1
+              size_gb: 200
+              boot_order: 3
+              bandwidth_limit: 10000000
+          nics:
+            - name: vNIC 0
+              type: VLAN
+              network: VLAN-300
+              boot_order: 4
+              firewall_override: Allow-All
+            - name: vNIC 1
+              type: VNET
+              network: PXE-VNET
+              boot_order: 1
+              mac_address: b4:d1:35:00:00:01
+
+        - name: Restart all of my Basic_VMs on ThinkAgile CP
+          tacp_instance:
+            api_key: "{{ api_key }}"
+            name: "{{ instance }}"
+            state: restarted
+          loop:
+            - Basic_VM1
+            - Basic_VM2
+            - Basic_VM3
+          loop_control:
+            loop_var: instance
+
+        - name: Delete Basic_VM1 from ThinkAgile CP
+          tacp_instance:
+            api_key: "{{ api_key }}"
+            name: Basic_VM1
+            state: absent
+
+        - name: Create a variety of VMs on TACP in a loop
+          tacp_instance:
+            api_key: "{{ api_key }}"
+            name: "{{ instance.name }}"
+            state: "{{ instance.state }}"
+            datacenter: Datacenter2
+            migration_zone: Zone2
+            template: "{{ instance.template }}"
+            storage_pool: Pool2
+            vcpu_cores: "{{ instance.vcpu_cores }}"
+            memory: "{{ instance.memory }}"
+            disks:
+              - name: Disk 0
+                size_gb: 100
+                boot_order: 1
+            nics:
+              - name: vNIC 0
+                type: "{{ instance.network_type }}"
+                network: "{{ instance.network_name }}"
+                mac_address: "{{ instance.mac_address }}"
+                boot_order: 2
+          loop:
+            - { name: CentOS VM 1,
+                state: started,
+                template: "CentOS 7.5 (64-bit) - Lenovo Template",
+                vcpu_cores: 2,
+                memory: 4096MB,
+                network_type: VLAN,
+                network_name: VLAN-15,
+                mac_address: b4:d1:35:00:0f:f0 }
+            - { name: RHEL VM 11,
+                state: stopped,
+                template: "RHEL 7.4 (Minimal) - Lenovo Template",
+                vcpu_cores: 6,
+                memory: 6g,
+                network_type: VNET,
+                network_name: Production-VNET,
+                mac_address: b4:d1:35:00:0f:f1 }
+            - { name: Windows Server 2019 VM 1,
+                state: started,
+                template: "Windows Server 2019 Standard - Lenovo Template",
+                vcpu_cores: 8,
+                memory: 16GB,
+                network_type: VNET,
+                network_name: Internal-VNET,
+                mac_address: b4:d1:35:00:0f:f2 }
+          loop_control:
+            loop_var: instance
+
+**tacp_network**
+
+.. code-block:: yaml
+
+   ---
+   - name: Test tacp_network Ansible module for ThinkAgile CP
+     hosts: localhost
+     gather_facts: false
+     tasks:
+      - name: Create a VLAN network on ThinkAgile CP
+        tacp_network:
+          api_key: "{{ api_key }}"
+          name: VLAN-15
+          state: present
+          network_type: VLAN
+          vlan_tag: 15
+
+      - name: Delete a VLAN network on ThinkAgile CP
+        tacp_network:
+          api_key: "{{ api_key }}"
+          name: VLAN-15
+          state: absent
+          network_type: VLAN
+
+      - name: Create a VNET network with an NFV on TACP
+        tacp_network:
+          api_key: "{{ api_key }}"
+          name:  Private VNET
+          state: present
+          network_type: VNET
+          autodeploy_nfv: True
+          network_address: 192.168.1.0
+          subnet_mask: 255.255.255.0
+          gateway: 192.168.1.1
+          dhcp:
+            dhcp_start: 192.168.1.100
+            dhcp_end: 192.168.1.200
+            domain_name: test.local
+            lease_time: 86400 # seconds, 24 hours
+            dns1: 1.1.1.1
+            dns2: 8.8.8.8
+            static_bindings:
+              - hostname: Host1
+                ip_address: 192.168.1.101
+                mac_address: b4:d1:35:00:0f:f1
+              - hostname: Host2
+                ip_address: 192.168.1.102
+                mac_address: b4:d1:35:00:0f:f2
+          routing:
+            type: VLAN
+            network: Lab-VLAN
+            address_mode: static
+            ip_address: 192.168.100.201
+            subnet_mask: 255.255.255.0
+            gateway: 192.168.100.1
+          nfv:
+            datacenter: Datacenter1
+            storage_pool: Pool1
+            migration_zone: Zone1
+            cpu_cores: 1
+            memory: 1G
+            auto_recovery: True
 
 Authors
 =======
+Lenovo (`@lenovo <http://github.com/lenovo/>`_)
 
-Ansible was created by `Michael DeHaan <https://github.com/mpdehaan>`_
-and has contributions from over 4700 users (and growing). Thanks everyone!
+Xander Madsen (`@xmadsen <http://github.com/xmadsen/>`_)
 
-`Ansible <https://www.ansible.com>`_ is sponsored by `Red Hat, Inc.
-<https://www.redhat.com>`_
+Marius Vigariu (`@mariusvigariu <http://github.com/mariusvigariu/>`_)
 
 License
 =======
@@ -95,21 +328,3 @@ License
 GNU General Public License v3.0 or later
 
 See `COPYING <COPYING>`_ to see the full text.
-
-.. |PyPI version| image:: https://img.shields.io/pypi/v/ansible.svg
-   :target: https://pypi.org/project/ansible
-.. |Docs badge| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
-   :target: https://docs.ansible.com/ansible/latest/
-.. |Build Status| image:: https://api.shippable.com/projects/573f79d02a8192902e20e34b/badge?branch=devel
-   :target: https://app.shippable.com/projects/573f79d02a8192902e20e34b
-.. |Chat badge| image:: https://img.shields.io/badge/chat-IRC-brightgreen.svg
-   :target: https://docs.ansible.com/ansible/latest/community/communication.html
-.. |Code Of Conduct| image:: https://img.shields.io/badge/code%20of%20conduct-Ansible-silver.svg
-   :target: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
-   :alt: Ansible Code of Conduct
-.. |Mailing Lists| image:: https://img.shields.io/badge/mailing%20lists-Ansible-orange.svg
-   :target: https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information
-   :alt: Ansible mailing lists
-.. |License| image:: https://img.shields.io/badge/license-GPL%20v3.0-brightgreen.svg
-   :target: COPYING
-   :alt: Repository License

--- a/README.rst
+++ b/README.rst
@@ -45,20 +45,28 @@ The tacp modules and module_utils files can be added to any of the following dfi
 
 ``[user@hostname ansible.lenovo-tacp]# mkdir -p ~/.ansible/plugins/``
 
-2. Copy the ``module_utils/tacp_ansible/`` directory from this ansible.lenovo-tacp repo into
+2. Create the ``~/.ansible/plugins/module_utils`` directory:
+
+``[user@hostname ansible.lenovo-tacp]# mkdir -p ~/.ansible/plugins/module_utils``
+
+3. Create the ``~/.ansible/plugins/modules/cloud`` directory:
+
+``[user@hostname ansible.lenovo-tacp]# mkdir -p ~/.ansible/plugins/modules/cloud``
+
+4. Copy the ``module_utils/tacp_ansible/`` directory from this ansible.lenovo-tacp repo into
    the local ansible installation's ``module_utils/`` directory. In this example the module files 
    are copied to the ``/usr/share/ansible/plugins`` location, which requires ``sudo``.
 
 ``[user@hostname ansible.lenovo-tacp]# sudo cp -R ./lib/ansible/module_utils/tacp_ansible 
 ~/.ansible/plugins/module_utils``
 
-3. Copy the ``modules/tacp/`` directory from this ansible.lenovo-tacp repo into
+5. Copy the ``modules/tacp/`` directory from this ansible.lenovo-tacp repo into
    the local ansible installation's ``modules/cloud/`` directory.
 
 ``[user@hostname ansible.lenovo-tacp]# sudo cp -R ./lib/ansible/modules/tacp 
 ~/.ansible/plugins/modules/cloud``
 
-4. Verify the manual installation worked:
+6. Verify the manual installation worked:
 
 .. code-block:: shell 
 

--- a/README.rst
+++ b/README.rst
@@ -43,34 +43,30 @@ The tacp modules and module_utils files can be added to any of the following dfi
 
 1. For example, create the ``~/.ansible/plugins/`` directory:
 
-``[user@hostname ansible.lenovo-tacp]# mkdir -p ~/.ansible/plugins/``
+``$ mkdir -p ~/.ansible/plugins/``
 
-2. Create the ``~/.ansible/plugins/module_utils`` directory:
+2. Create the ``~/.ansible/plugins/module_utils`` and ``~/.ansible/plugins/modules/cloud`` directories:
 
-``[user@hostname ansible.lenovo-tacp]# mkdir -p ~/.ansible/plugins/module_utils``
-
-3. Create the ``~/.ansible/plugins/modules/cloud`` directory:
-
-``[user@hostname ansible.lenovo-tacp]# mkdir -p ~/.ansible/plugins/modules/cloud``
+``$ mkdir -p ~/.ansible/plugins/module_utils ~/.ansible/plugins/modules/cloud``
 
 4. Copy the ``module_utils/tacp_ansible/`` directory from this ansible.lenovo-tacp repo into
-   the local ansible installation's ``module_utils/`` directory. In this example the module files 
+   the local Ansible installation's ``module_utils/`` directory. In this example the module files 
    are copied to the ``/usr/share/ansible/plugins`` location, which requires ``sudo``.
 
-``[user@hostname ansible.lenovo-tacp]# sudo cp -R ./lib/ansible/module_utils/tacp_ansible 
+``$ cp -R ./lib/ansible/module_utils/tacp_ansible 
 ~/.ansible/plugins/module_utils``
 
 5. Copy the ``modules/tacp/`` directory from this ansible.lenovo-tacp repo into
-   the local ansible installation's ``modules/cloud/`` directory.
+   the local Ansible installation's ``modules/cloud/`` directory.
 
-``[user@hostname ansible.lenovo-tacp]# sudo cp -R ./lib/ansible/modules/tacp 
+``$ cp -R ./lib/ansible/modules/tacp 
 ~/.ansible/plugins/modules/cloud``
 
 6. Verify the manual installation worked:
 
 .. code-block:: shell 
 
-  [user@hostname ansible.lenovo-tacp]# ansible-doc -t module tacp_instance
+  $ ansible-doc -t module tacp_instance
   > TACP_INSTANCE    (/home/user/.ansible/plugins/modules/cloud/tacp/tacp_instance.py)
 
         This module can be used to create new application instances on the ThinkAgile CP cloud platform, as well as delete and modify power states of existing application instances. Currently this module cannot modify the resources of

--- a/README.rst
+++ b/README.rst
@@ -41,9 +41,9 @@ The tacp modules and module_utils files can be added to any of the following dfi
 
 
 Copy the ``module_utils/tacp_ansible/`` directory from this ansible.lenovo-tacp repo into
-the local ansible installation's ``module_utils/`` directory.
+the local ansible installation's ``module_utils/`` directory. In this example the module files are copied to the ``/usr/share/ansible/plugins`` location, which requires ``sudo``.
 
-``[user@hostname ansible.lenovo-tacp]# cp -R ./lib/ansible/module_utils/tacp_ansible 
+``[user@hostname ansible.lenovo-tacp]# sudo cp -R ./lib/ansible/module_utils/tacp_ansible 
 /usr/share/ansible/plugins/module_utils``
 
 |
@@ -51,7 +51,7 @@ the local ansible installation's ``module_utils/`` directory.
 Copy the ``modules/tacp/`` directory from this ansible.lenovo-tacp repo into
 the local ansible installation's ``modules/cloud/`` directory.
 
-``[user@hostname ansible.lenovo-tacp]# cp -R ./lib/ansible/modules/tacp 
+``[user@hostname ansible.lenovo-tacp]# sudo cp -R ./lib/ansible/modules/tacp 
 /usr/share/ansible/plugins/modules/cloud``
 
 Examples

--- a/lib/ansible/modules/tacp/tacp_info.py
+++ b/lib/ansible/modules/tacp/tacp_info.py
@@ -22,56 +22,79 @@ DOCUMENTATION = '''
 ---
 module: tacp_info
 
-short_description: This is my test module
-
-version_added: "2.9"
+short_description: Get facts about various resources in ThinkAgile CP.
 
 description:
-    - "This is my longer description explaining my test module"
-
-options:
-    name:
-        description:
-            - This is the message to send to the test module
-        required: true
-    new:
-        description:
-            - Control to demo if the result of this module is changed or not
-        required: false
-
-extends_documentation_fragment:
-    - tacp
+    - This module can be used to retrieve data about various types of resources
+        in the ThinkAgile CP cloud platform.
 
 author:
+    - Lenovo (@lenovo)
     - Xander Madsen (@xmadsen)
+
+requirements:
+- tacp
+
+options:
+    api_key:
+        description:
+            - An API key generated in the Developer Options in the ThinkAgile
+                CP portal. This is required to perform any operations with this
+                module.
+        required: true
+        type: str
+    resource:
+        description:
+           - The type of resource the user wants to retrieve data about.
+           - Valid choices are:
+              - application
+              - application_group
+              - category
+              - datacenter
+              - firewall_profile
+              - instance
+              - marketplace_template
+              - migration_zone
+              - site
+              - storage_pool
+              - tag
+              - template
+              - user
+              - vlan
+              - vnet
+        required: true
+        type: str
 '''
 
 EXAMPLES = '''
-# Pass in a message
-- name: Test with a message
-  tacp_instance:
-    name: hello world
+- name: Get details about application instances from ThinkAgile CP
+  tacp_info:
+    api_key: "{{ api_key}}"
+    resource: instance
 
-# pass in a message and have changed true
-- name: Test with a message and changed output
-  tacp_instance:
-    name: hello world
-    new: true
+- name: Get details about datacenters and networks from ThinkAgile CP
+  tacp_info:
+    api_key: "{{ api_key}}"
+    resource: "{{ resource }}"
+  loop:
+    - datacenter
+    - vlan
+    - vnet
+  loop_control:
+    loop_var: resource
 
-# fail the module
-- name: Test failure of the module
-  tacp_instance:
-    name: fail me
+- name: Get a list of the available marketplace application templates from
+        ThinkAgile CP
+  tacp_info:
+    api_key: "{{ api_key}}"
+    resource: marketplace_template
 '''
 
 RETURN = '''
-original_message:
-    description: The original name param that was passed in
-    type: str
-    returned: always
-message:
-    description: The output message that the test module generates
-    type: str
+resource:
+    description: A dict containing a key with the name of the resource type,
+                    and a list of the returned resources as a value.
+    type: dict
     returned: always
 '''
 
@@ -183,7 +206,8 @@ def run_module():
                 item['tags'] = tacp_utils.fill_in_missing_names_by_uuid(
                     item['tags'], tag_resource, 'tags')
 
-    result[module.params['resource']] = items
+    result['resource'] = {}
+    result['resource'][module.params['resource']] = items
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/tacp/tacp_info.py
+++ b/lib/ansible/modules/tacp/tacp_info.py
@@ -25,45 +25,46 @@ module: tacp_info
 short_description: Get facts about various resources in ThinkAgile CP.
 
 description:
-    - This module can be used to retrieve data about various types of resources
-        in the ThinkAgile CP cloud platform.
+  - This module can be used to retrieve data about various types of resources
+    in the ThinkAgile CP cloud platform.
 
 author:
-    - Lenovo (@lenovo)
-    - Xander Madsen (@xmadsen)
+  - Lenovo (@lenovo)
+  - Xander Madsen (@xmadsen)
 
 requirements:
-- tacp
+  - tacp
 
 options:
-    api_key:
-        description:
-            - An API key generated in the Developer Options in the ThinkAgile
-                CP portal. This is required to perform any operations with this
-                module.
-        required: true
-        type: str
-    resource:
-        description:
-           - The type of resource the user wants to retrieve data about.
-           - Valid choices are:
-              - application
-              - application_group
-              - category
-              - datacenter
-              - firewall_profile
-              - instance
-              - marketplace_template
-              - migration_zone
-              - site
-              - storage_pool
-              - tag
-              - template
-              - user
-              - vlan
-              - vnet
-        required: true
-        type: str
+  api_key:
+    description:
+      - An API key generated in the Developer Options in the ThinkAgile
+        CP portal. This is required to perform any operations with this
+        module.
+    required: true
+    type: str
+  resource:
+    description:
+      - The type of resource the user wants to retrieve data about.
+      - Valid choices are
+        - application
+        - application_group
+        - category
+        - datacenter
+        - firewall_profile
+        - instance
+        - marketplace_template
+        - migration_zone
+        - site
+        - storage_pool
+        - tag
+        - template
+        - user
+        - vlan
+        - vnet
+    required: true
+    type: str
+
 '''
 
 EXAMPLES = '''
@@ -92,10 +93,11 @@ EXAMPLES = '''
 
 RETURN = '''
 resource:
-    description: A dict containing a key with the name of the resource type,
-                    and a list of the returned resources as a value.
-    type: dict
-    returned: always
+  description: A dict containing a key with the name of the resource type,
+    and a list of the returned resources as a value.
+  type: dict
+  returned: always
+
 '''
 
 module_args = {

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -252,9 +252,6 @@ options:
               .
         required: false
         type: str
-
-author:
-    - Xander Madsen (@xmadsen)
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -25,231 +25,232 @@ DOCUMENTATION = '''
 module: tacp_instance
 
 short_description: Creates and modifies power state of application instances on
-                    ThinkAgile CP.
+  ThinkAgile CP.
 
 description:
-    - 'This module can be used to create new application instances on the
-        ThinkAgile CP cloud platform, as well as delete and modify power states
-        of existing application instances.'
-    - 'Currently this module cannot modify the resources of existing
-        application instances aside from performing deletion and power state
-        operations.'
+  - "This module can be used to create new application instances on the
+    ThinkAgile CP cloud platform, as well as delete and modify power states
+    of existing application instances."
+  - "Currently this module cannot modify the resources of existing
+    application instances aside from performing deletion and power state
+    operations."
 author:
-    - Lenovo (@lenovo)
-    - Xander Madsen (@xmadsen)
+  - Lenovo (@lenovo)
+  - Xander Madsen (@xmadsen)
 
 requirements:
-- tacp
+  - tacp
 
 options:
-    api_key:
+  api_key:
+    description:
+      - An API key generated in the Developer Options in the ThinkAgile
+        CP portal. This is required to perform any operations with this
+        module.
+    required: true
+    type: str
+  name:
+    description:
+      - This is the name of the instance to be created or modified
+    required: true
+    type: str
+  state:
+    description:
+      - The desired state for the application instance in question. All
+        options except 'absent' will perform a power operation if
+        necessary, while 'absent' deletes the application instance with
+        the provided name if it exists.
+    choices:
+      - started
+      - shutdown
+      - stopped
+      - restarted
+      - force_restarted
+      - paused
+      - absent
+  datacenter:
+    description:
+      - The name of the virtual datacenter that the instance will be
+        created in. Only required when creating a new instance.
+    required: false
+    type: str
+  migration_zone:
+    description:
+      - The name of the migration zone that the instance will be created
+        in. Only required when creating a new instance.
+    required: false
+    type: str
+  template:
+    description:
+      - The name of the template used as a basis for the creation of the
+        instance. Only required when creating a new instance.
+    required: false
+    type: str
+  storage_pool:
+    description:
+      - The name of the storage pool that the instance's disks will be
+        stored in. Only required when creating a new instance.
+    required: false
+    type: str
+  vcpu_cores:
+    description:
+      - The number of virtual CPU cores that the application instance
+        will have when it is created. Only required when creating a new
+        instance.
+    required: false
+    type: int
+  memory:
+    description:
+      - The amount of virtual memory (RAM) that the application instance
+        will have when it is created. Can be expressed with various
+        units. Only required when creating a new instance.
+    required: false
+    type: str
+  disks:
+    description:
+      - An array of disks that will be associated with the application
+        instance when it is created.
+      - Must contain any disks that the template contains, and the names
+        must match for any of those such disks. Only required when
+        creating a new instance.
+    required: false
+    type: list
+    suboptions:
+      name:
         description:
-            - An API key generated in the Developer Options in the ThinkAgile
-                CP portal. This is required to perform any operations with this
-                module.
+          - The name of the disk. If the specified disk is not part
+            of the template, it can be named anything (except the
+            name of a disk in the template).
         required: true
         type: str
-    name:
+      size_gb:
         description:
-            - This is the name of the instance to be created or modified
+          - The size of the disk in GB. Can be expressed as a float.
         required: true
-        type: str
-    state:
+        type: float
+      boot_order:
         description:
-            - The desired state for the application instance in question. All
-                options except 'absent' will perform a power operation if
-                necessary, while 'absent' deletes the application instance with
-                the provided name if it exists.
-        choices:
-            - started
-            - shutdown
-            - stopped
-            - restarted
-            - force_restarted
-            - paused
-            - absent
-    datacenter:
+          - The place in the boot order for the disk. The overall
+            boot order must begin at 1, and every NIC and disk must
+            have an order provided.
+        required: true
+        type: int
+      bandwidth_limit:
         description:
-            - The name of the virtual datacenter that the instance will be
-              created in. Only required when creating a new instance.
-        required: false
-        type: str
-    migration_zone:
-        description:
-            - The name of the migration zone that the instance will be created
-              in. Only required when creating a new instance.
-        required: false
-        type: str
-    template:
-        description:
-            - The name of the template used as a basis for the creation of the
-              instance. Only required when creating a new instance.
-        required: false
-        type: str
-    storage_pool:
-        description:
-            - The name of the storage pool that the instance's disks will be
-              stored in. Only required when creating a new instance.
-        required: false
-        type: str
-    vcpu_cores:
-        description:
-            - The number of virtual CPU cores that the application instance
-              will have when it is created. Only required when creating a new
-              instance.
+          - A limit to the bandwidth usage allowed for this disk.
+            Must be at least 5000000 (5 Mbps).
         required: false
         type: int
-    memory:
+      iops_limit:
         description:
-            - The amount of virtual memory (RAM) that the application instance
-              will have when it is created. Can be expressed with various
-              units. Only required when creating a new instance.
+          - A limit to the total IOPS allowed for this disk.
+            Must be at least 50.
         required: false
-        type: str
-    disks:
-        description:
-            - An array of disks that will be associated with the application
-              instance when it is created.
-            - Must contain any disks that the template contains, and the names
-              must match for any of those such disks. Only required when
-              creating a new instance.
-        required: false
-        type: list
-        suboptions:
-            name:
-                description:
-                    - The name of the disk. If the specified disk is not part
-                      of the template, it can be named anything (except the
-                      name of a disk in the template).
-                required: true
-                type: str
-            size_gb:
-                description:
-                    - The size of the disk in GB. Can be expressed as a float.
-                required: true
-                type: float
-            boot_order:
-                description:
-                    - The place in the boot order for the disk. The overall
-                      boot order must begin at 1, and every NIC and disk must
-                      have an order provided.
-                required: true
-                type: int
-            bandwidth_limit:
-                description:
-                    - A limit to the bandwidth usage allowed for this disk.
-                      Must be at least 5000000 (5 Mbps).
-                required: false
-                type: int
-            iops_limit:
-                description:
-                    - A limit to the total IOPS allowed for this disk.
-                      Must be at least 50.
-                required: false
-                type: int
-    nics:
-        description:
-            - An array of NICs that will be associated with the application
-              instance when it is created.
-            - Must contain any NICs that the template contains, and the names
-              must match for any of those such NICs. Only required when
-              creating a new instance.
-        required: false
-        type: list
-        suboptions:
-            name:
-                description:
-                    - The name of the NIC. If the specified NIC is not part
-                      of the template, it can be named anything (except the
-                      name of a NIC in the template).
-                required: true
-                type: str
-            type:
-                description:
-                    - The type of network that the NIC will be a part of.
-                    - Valid chocies are either "VNET" or "VLAN".
-                required: true
-                type: str
-            network:
-                description:
-                    - The name of the network that the NIC will be a part of.
-                    - There must be an existing network of the provided type
-                      that has the provided network name to succeed.
-                required: true
-                type: str
-            boot_order:
-                description:
-                    - The place in the boot order for the NIC. The overall boot
-                      order must begin at 1, and every NIC and disk must have
-                      an order provided.
-                required: true
-                type: int
-            automatic_mac_address:
-                description:
-                    - Whether this interface should be automatically assigned
-                      a MAC address.
-                    - Providing a MAC address to the mac_address field sets
-                      this value to false.
-                required: false
-                type: bool
-            mac_address:
-                description:
-                    - A static MAC address to be assigned to the NIC. Should
-                      not exist on any other interfaces on the network.
-                    - Should be of the format aa:bb:cc:dd:ee:ff
-                    - If this is set, 'automatic_mac_address' is automatically
-                      set to false.
-                required: false
-                type: str
-            firewall_override:
-                description:
-                    - The name of a firewall override that exists in the
-                      datacenter that the NIC's instance will reside in.
-                required: false
-                type: str
-    vtx_enabled:
-        description:
-            - Whether or not VT-x nested virtualization features should be
-              enabled for the instance. Enabled by default.
-        required: false
-        type: bool
-    auto_recovery_enabled:
-        description:
-            - Whether or not the instance should be restarted on a different
-              host node in the event that its host node fails. Defaults to
-              true.
-        required: false
-        type: bool
+        type: int
+  nics:
     description:
+      - An array of NICs that will be associated with the application
+        instance when it is created.
+      - Must contain any NICs that the template contains, and the names
+        must match for any of those such NICs. Only required when
+        creating a new instance.
+    required: false
+    type: list
+    suboptions:
+      name:
         description:
-            - A textual description of the instance. Defaults to any
-              description that the source template come with.
+          - The name of the NIC. If the specified NIC is not part
+            of the template, it can be named anything (except the
+            name of a NIC in the template).
+        required: true
+        type: str
+      type:
+        description:
+          - The type of network that the NIC will be a part of.
+          - Valid chocies are either "VNET" or "VLAN".
+        required: true
+        type: str
+      network:
+        description:
+          - The name of the network that the NIC will be a part of.
+          - There must be an existing network of the provided type
+            that has the provided network name to succeed.
+        required: true
+        type: str
+      boot_order:
+        description:
+          - The place in the boot order for the NIC. The overall boot
+            order must begin at 1, and every NIC and disk must have
+            an order provided.
+        required: true
+        type: int
+      automatic_mac_address:
+        description:
+          - Whether this interface should be automatically assigned
+            a MAC address.
+          - Providing a MAC address to the mac_address field sets
+            this value to false.
+        required: false
+        type: bool
+      mac_address:
+        description:
+          - A static MAC address to be assigned to the NIC. Should
+            not exist on any other interfaces on the network.
+          - Should be of the format aa:bb:cc:dd:ee:ff
+          - If this is set, 'automatic_mac_address' is automatically
+            set to false.
         required: false
         type: str
-    vm_mode:
+      firewall_override:
         description:
-            - Sets the instance mode. Set to "Enhanced" by default.
-            - Valid choices are "Enhanced" and "Compatibility"
-            - Any instance can boot in Compatibility mode.
-            - In Enhanced mode, Virtio drivers must be present in the template
-              in order to boot.
-            - Additionally, in Enhanced mode:
-                - Storage disks are exported as virtio iSCSI devices
-                - vNICs are exported as virtio vNICs
-                - Snapshots will be application consistent (when ThinkAgile CP
-                  Guest Agent is installed) if the guest OS supports freeze and
-                  thaw
-                - CPU and Memory Statistics are available (When ThinkAgile CP
-                  Guest Agent is installed)
+          - The name of a firewall override that exists in the
+            datacenter that the NIC's instance will reside in.
         required: false
         type: str
-    application_group:
-        description:
-            - The name of an application group that the instance will be put
-              in. Creates it in the virtual datacenter if it does not yet exist
-              .
-        required: false
-        type: str
+  vtx_enabled:
+    description:
+      - Whether or not VT-x nested virtualization features should be
+        enabled for the instance. Enabled by default.
+    required: false
+    type: bool
+  auto_recovery_enabled:
+    description:
+      - Whether or not the instance should be restarted on a different
+        host node in the event that its host node fails. Defaults to
+        true.
+    required: false
+    type: bool
+  description:
+    description:
+      - A textual description of the instance. Defaults to any
+        description that the source template come with.
+    required: false
+    type: str
+  vm_mode:
+    description:
+      - Sets the instance mode. Set to "Enhanced" by default.
+      - Valid choices are "Enhanced" and "Compatibility"
+      - Any instance can boot in Compatibility mode.
+      - In Enhanced mode, Virtio drivers must be present in the template
+        in order to boot.
+      - Additionally, in Enhanced mode
+        - Storage disks are exported as virtio iSCSI devices
+        - vNICs are exported as virtio vNICs
+        - Snapshots will be application consistent (when ThinkAgile CP
+        Guest Agent is installed) if the guest OS supports freeze and
+        thaw
+        - CPU and Memory Statistics are available (When ThinkAgile CP
+        Guest Agent is installed)
+    required: false
+    type: str
+  application_group:
+    description:
+      - The name of an application group that the instance will be put
+        in. Creates it in the virtual datacenter if it does not yet exist
+        .
+    required: false
+    type: str
+
 '''
 
 EXAMPLES = '''
@@ -430,15 +431,16 @@ EXAMPLES = '''
 
 RETURN = '''
 instance:
-    description: The final state of the application instance if it still exists.
-    type: dict
-    returned: success
+  description: The final state of the application instance if it still exists.
+  type: dict
+  returned: success
 
 msg:
-    description: An error message in the event of invalid input or other
-        unexpected behavior during module execution.
-    type: str
-    returned: failure
+  description: An error message in the event of invalid input or other
+    unexpected behavior during module execution.
+  type: str
+  returned: failure
+
 '''
 
 

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -435,13 +435,9 @@ EXAMPLES = '''
 
 RETURN = '''
 instance:
-    description: The final state of the application instance
+    description: The final state of the application instance if it still exists.
     type: str
-    returned: sometimes
-message:
-    description: 
-    type: str
-    returned: alw
+    returned: success
 '''
 
 

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -26,25 +26,232 @@ DOCUMENTATION = '''
 ---
 module: tacp_instance
 
-short_description: This is my test module
-
-version_added: "2.9"
+short_description: Creates and modifies power state of application instances on
+                    ThinkAgile CP.
 
 description:
-    - "This is my longer description explaining my test module"
+    - 'This module can be used to create new application instances on the
+        ThinkAgile CP cloud platform, a well as delete and modify power states
+        of existing application instances.'
+    - 'Currently this module cannot modify the resources of existing
+        application instances aside from performing deletion and power state
+        operations.'
+author:
+    - Lenovo (@lenovo)
+    - Xander Madsen (@xmadsen)
+
+requirements:
+- tacp
 
 options:
+    api_key:
+        description:
+            - An API key generated in the Developer Options in the ThinkAgile
+                CP portal. This is required to perform any operations with this
+                module.
+        required: true
+        type: str
     name:
         description:
-            - This is the message to send to the test module
+            - This is the name of the instance to be created or modified
         required: true
-    new:
+        type: str
+    state:
         description:
-            - Control to demo if the result of this module is changed or not
+            - The desired state for the application instance in question. All
+                options except 'absent' will perform a power operation if
+                necessary, while 'absent' deletes the application instance with
+                the provided name if it exists.
+        choices:
+            - started
+            - shutdown
+            - stopped
+            - restarted
+            - force_restarted
+            - paused
+            - absent
+    datacenter:
+        description:
+            - The name of the virtual datacenter that the instance will be
+              created in. Only required when creating a new instance.
         required: false
-
-extends_documentation_fragment:
-    - tacp
+        type: str
+    migration_zone:
+        description:
+            - The name of the migration zone that the instance will be created
+              in. Only required when creating a new instance.
+        required: false
+        type: str
+    template:
+        description:
+            - The name of the template used as a basis for the creation of the
+              instance. Only required when creating a new instance.
+        required: false
+        type: str
+    storage_pool:
+        description:
+            - The name of the storage pool that the instance's disks will be
+              stored in. Only required when creating a new instance.
+        required: false
+        type: str
+    vcpu_cores:
+        description:
+            - The number of virtual CPU cores that the application instance
+              will have when it is created. Only required when creating a new
+              instance.
+        required: false
+        type: int
+    memory:
+        description:
+            - The amount of virtual memory (RAM) that the application instance
+              will have when it is created. Can be expressed with various
+              units. Only required when creating a new instance.
+        required: false
+        type: str
+    disks:
+        description:
+            - An array of disks that will be associated with the application
+              instance when it is created.
+            - Must contain any disks that the template contains, and the names
+              must match for any of those such disks. Only required when
+              creating a new instance.
+        required: false
+        type: list
+        suboptions:
+            name:
+                description:
+                    - The name of the disk. If the specified disk is not part
+                      of the template, it can be named anything (except the
+                      name of a disk in the template).
+                required: true
+                type: str
+            size_gb:
+                description:
+                    - The size of the disk in GB. Can be expressed as a float.
+                required: true
+                type: float
+            boot_order:
+                description:
+                    - The place in the boot order for the disk. The overall boot
+                      order must begin at 1, and every NIC and disk must have
+                      an order provided.
+                required: true
+                type: int
+            bandwidth_limit:
+                description:
+                    - A limit to the bandwidth usage allowed for this disk.
+                      Must be at least 5000000 (5 Mbps).
+                required: false
+                type: int
+            iops_limit:
+                description:
+                    - A limit to the total IOPS allowed for this disk.
+                      Must be at least 50.
+                required: false
+                type: int
+    nics:
+        description:
+            - An array of NICs that will be associated with the application
+              instance when it is created.
+            - Must contain any NICs that the template contains, and the names
+              must match for any of those such NICs. Only required when
+              creating a new instance.
+        required: false
+        type: list
+        suboptions:
+            name:
+                description:
+                    - The name of the NIC. If the specified NIC is not part
+                      of the template, it can be named anything (except the
+                      name of a NIC in the template).
+                required: true
+                type: str
+            type:
+                description:
+                    - The type of network that the NIC will be a part of.
+                    - Valid chocies are either "VNET" or "VLAN".
+                required: true
+                type: str
+            network:
+                description:
+                    - The name of the network that the NIC will be a part of.
+                    - There must be an existing network of the provided type
+                      that has the provided network name to succeed.
+                required: true
+                type: str
+            boot_order:
+                description:
+                    - The place in the boot order for the NIC. The overall boot
+                      order must begin at 1, and every NIC and disk must have
+                      an order provided.
+                required: true
+                type: int
+            automatic_mac_address:
+                description:
+                    - Whether this interface should be automatically assigned
+                      a MAC address.
+                    - Providing a MAC address to the mac_address field sets
+                      this value to false.
+                required: false
+                type: bool
+            mac_address:
+                description:
+                    - A static MAC address to be assigned to the NIC. Should
+                      not exist on any other interfaces on the network.
+                    - Should be of the format aa:bb:cc:dd:ee:ff
+                    - If this is set, 'automatic_mac_address' is automatically
+                      set to false.
+                required: false
+                type: str
+            firewall_override:
+                description:
+                    - The name of a firewall override that exists in the
+                      datacenter that the NIC's instance will reside in.
+                required: false
+                type: str
+    vtx_enabled:
+        description:
+            - Whether or not VT-x nested virtualization features should be
+              enabled for the instance. Enabled by default.
+        required: false
+        type: bool
+    auto_recovery_enabled:
+        description:
+            - Whether or not the instance should be restarted on a different 
+              host node in the event that its host node fails. Defaults to
+              true.
+        required: false
+        type: bool
+    description:
+        description:
+            - A textual description of the instance. Defaults to any 
+              description that the source template come with.
+        required: false
+        type: str
+    vm_mode:
+        description:
+            - Sets the instance mode. Set to "Enhanced" by default.
+            - Valid choices are "Enhanced" and "Compatibility"
+            - Any instance can boot in Compatibility mode.
+            - In Enhanced mode, Virtio drivers must be present in the template
+              in order to boot.
+            - Additionally, in Enhanced mode:
+                - Storage disks are exported as virtio iSCSI devices
+                - vNICs are exported as virtio vNICs
+                - Snapshots will be application consistent (when ThinkAgile CP
+                  Guest Agent is installed) if the guest OS supports freeze and
+                  thaw
+                - CPU and Memory Statistics are available (When ThinkAgile CP
+                  Guest Agent is installed)
+        required: false
+        type: str
+    application_group:
+        description:
+            - The name of an application group that the instance will be put 
+              in. Creates it in the virtual datacenter if it does not yet exist
+              .
+        required: false
+        type: str
 
 author:
     - Xander Madsen (@xmadsen)

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -31,7 +31,7 @@ short_description: Creates and modifies power state of application instances on
 
 description:
     - 'This module can be used to create new application instances on the
-        ThinkAgile CP cloud platform, a well as delete and modify power states
+        ThinkAgile CP cloud platform, as well as delete and modify power states
         of existing application instances.'
     - 'Currently this module cannot modify the resources of existing
         application instances aside from performing deletion and power state

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -436,8 +436,14 @@ EXAMPLES = '''
 RETURN = '''
 instance:
     description: The final state of the application instance if it still exists.
-    type: str
+    type: dict
     returned: success
+
+msg:
+    description: An error message in the event of invalid input or other
+        unexpected behavior during module execution.
+    type: str
+    returned: failure
 '''
 
 

--- a/lib/ansible/modules/tacp/tacp_network.py
+++ b/lib/ansible/modules/tacp/tacp_network.py
@@ -91,7 +91,7 @@ options:
     autodeploy_nfv:
         description:
             - Whether the network function virtualization (NFV) instance
-                will be create along with the VNET network.
+                will be created along with the VNET network.
             - If this is set to False, the VNET network will need an NFV
                 added manually later before it will work properly.
             - Only valid for VNET network types.
@@ -276,32 +276,100 @@ options:
 '''
 
 EXAMPLES = '''
-# Pass in a message
-- name: Test with a message
-  tacp_instance:
-    name: hello world
+- name: Create a VLAN network on ThinkAgile CP
+    tacp_network:
+      api_key: "{{ api_key }}"
+      name: VLAN-15
+      state: present
+      network_type: VLAN
+      vlan_tag: 15
 
-# pass in a message and have changed true
-- name: Test with a message and changed output
-  tacp_instance:
-    name: hello world
-    new: true
+- name: Delete a VLAN network on ThinkAgile CP
+    tacp_network:
+      api_key: "{{ api_key }}"
+      name: VLAN-15
+      state: absent
+      network_type: VLAN
 
-# fail the module
-- name: Test failure of the module
-  tacp_instance:
-    name: fail me
+- name: Create a VNET network with an NFV on TACP
+    tacp_network:
+      api_key: "{{ api_key }}"
+      name:  Private VNET
+      state: present
+      network_type: VNET
+      autodeploy_nfv: True
+      network_address: 192.168.1.0
+      subnet_mask: 255.255.255.0
+      gateway: 192.168.1.1
+      dhcp:
+        dhcp_start: 192.168.1.100
+        dhcp_end: 192.168.1.200
+        domain_name: test.local
+        lease_time: 86400 # seconds, 24 hours
+        dns1: 1.1.1.1
+        dns2: 8.8.8.8
+      routing:
+        type: VLAN
+        network: Lab-VLAN
+        address_mode: static
+        ip_address: 192.168.100.201
+        subnet_mask: 255.255.255.0
+        gateway: 192.168.100.1
+      nfv:
+        datacenter: Datacenter1
+        storage_pool: Pool1
+        migration_zone: Zone1
+        cpu_cores: 1
+        memory: 1G
+        auto_recovery: True
+
+- name: Create a VNET network with an NFV and static bindings on TACP
+    tacp_network:
+      api_key: "{{ api_key }}"
+      name:  Private VNET
+      state: present
+      network_type: VNET
+      autodeploy_nfv: True
+      network_address: 192.168.1.0
+      subnet_mask: 255.255.255.0
+      gateway: 192.168.1.1
+      dhcp:
+        dhcp_start: 192.168.1.100
+        dhcp_end: 192.168.1.200
+        domain_name: test.local
+        lease_time: 86400 # seconds, 24 hours
+        dns1: 1.1.1.1
+        dns2: 8.8.8.8
+        static_bindings:
+          - hostname: Host1
+            ip_address: 192.168.1.101
+            mac_address: b4:d1:35:00:0f:f1
+          - hostname: Host2
+            ip_address: 192.168.1.102
+            mac_address: b4:d1:35:00:0f:f2
+      routing:
+        type: VLAN
+        network: Lab-VLAN
+        address_mode: static
+        ip_address: 192.168.100.201
+        subnet_mask: 255.255.255.0
+        gateway: 192.168.100.1
+      nfv:
+        datacenter: Datacenter1
+        storage_pool: Pool1
+        migration_zone: Zone1
+        cpu_cores: 1
+        memory: 1G
+        auto_recovery: True
 '''
 
 RETURN = '''
-original_message:
-    description: The original name param that was passed in
+msg:
+    description: 
+        - An error message in the event of invalid input or other
+        unexpected behavior during module execution.
     type: str
-    returned: always
-message:
-    description: The output message that the test module generates
-    type: str
-    returned: always
+    returned: failure
 '''
 
 

--- a/lib/ansible/modules/tacp/tacp_network.py
+++ b/lib/ansible/modules/tacp/tacp_network.py
@@ -53,7 +53,7 @@ options:
         type: str
     state:
         description:
-            - The desired state for the network. 
+            - The desired state for the network.
             - Only valid for VLAN networks.
         required: false
         default: present
@@ -206,8 +206,8 @@ options:
                 type: str
             static_bindings:
                 description:
-                    - A list of static DHCP bindings, each binding requires at least
-                        an ip_address and mac_address value as a dict.
+                    - A list of static DHCP bindings, each binding requires at
+                        least an ip_address and mac_address value as a dict.
                 required: False
                 type: list
                 suboptions:
@@ -365,7 +365,7 @@ EXAMPLES = '''
 
 RETURN = '''
 msg:
-    description: 
+    description:
         - An error message in the event of invalid input or other
         unexpected behavior during module execution.
     type: str

--- a/lib/ansible/modules/tacp/tacp_network.py
+++ b/lib/ansible/modules/tacp/tacp_network.py
@@ -26,253 +26,254 @@ module: tacp_network
 short_description: Creates and deletes VLAN and VNET networks on ThinkAgile CP.
 
 description:
-    - 'This module can be used to create new VLAN and VNET networks on the
-        ThinkAgile CP cloud platform, as well as delete existing networks.'
-    - 'Currently this module cannot modify the settings of existing
-        networks; all settings must be specified at creation time.'
+  - "This module can be used to create new VLAN and VNET networks on the
+    ThinkAgile CP cloud platform, as well as delete existing networks."
+  - "Currently this module cannot modify the settings of existing
+    networks; all settings must be specified at creation time."
 
 author:
-    - Lenovo (@lenovo)
-    - Xander Madsen (@xmadsen)
+  - Lenovo (@lenovo)
+  - Xander Madsen (@xmadsen)
 
 requirements:
-- tacp
+  - tacp
 
 options:
-    api_key:
+  api_key:
+    description:
+      - An API key generated in the Developer Options in the ThinkAgile
+        CP portal. This is required to perform any operations with this
+        module.
+    required: true
+    type: str
+  name:
+    description:
+      - This is the name of the network to be created or deleted.
+    required: true
+    type: str
+  state:
+    description:
+      - The desired state for the network.
+      - Only valid for VLAN networks.
+    required: false
+    default: present
+    type: str
+  network_type:
+    description:
+      - The type of network. Valid choices are either "VNET" or "VLAN".
+    required: True
+    type: str
+  site_name:
+    description:
+      - The name of the site that the network will be a part of.
+      - If only one site exists, that site will be used by default and
+        this parameter is unneeded.
+    required: False
+    type: str
+  vlan_tag:
+    description:
+      - The VLAN ID to tag the network traffic with.
+      - Must be in the range of 1-4094.
+      - Only valid for VLAN network types.
+    required: False
+    type: int
+  firewall_override:
+    description:
+      - The name of a firewall override to be assigned to a VNET.
+      - Only valid for VNET network types.
+    required: False
+    type: str
+  firewall_profile:
+    description:
+      - The name of a firewall profile to be assigned to a VNET.
+    required: False
+    type: str
+  autodeploy_nfv:
+    description:
+      - Whether the network function virtualization (NFV) instance
+        will be created along with the VNET network.
+      - If this is set to False, the VNET network will need an NFV
+        added manually later before it will work properly.
+      - Only valid for VNET network types.
+    required: False
+    type: bool
+  nfv:
+    description:
+      - The settings to create an NFV instance to provide routing and
+        DHCP functionality to the VNET.
+      - Required if autodeploy_nfv is set to true.
+      - Only valid for VNET network types.
+    required: False
+    type: dict
+    suboptions:
+      datacenter:
         description:
-            - An API key generated in the Developer Options in the ThinkAgile
-                CP portal. This is required to perform any operations with this
-                module.
-        required: true
-        type: str
-    name:
-        description:
-            - This is the name of the network to be created or deleted.
-        required: true
-        type: str
-    state:
-        description:
-            - The desired state for the network.
-            - Only valid for VLAN networks.
+          - The name of the virtual datacenter that the NFV instance
+            will be created in. Only required when creating an NFV
+            instance.
         required: false
-        default: present
         type: str
-    network_type:
+      storage_pool:
         description:
-            - The type of network. Valid choices are either "VNET" or "VLAN".
-        required: True
+          - The name of the storage pool that the NFV instance's
+            disks will be stored in. Only required when creating a
+            new instance.
+        required: false
         type: str
-    site_name:
-        description: 
-            - The name of the site that the network will be a part of.
-            - If only one site exists, that site will be used by default and
-                this parameter is unneeded.
+      migration_zone:
+        description:
+          - The name of the migration zone that the NFV instance will
+            be created in. Only required when creating a new NFV
+            instance.
+        required: false
+        type: str
+      cpu_cores:
+        description:
+          - The number of virtual CPU cores that the NFV instance
+            will have when it is created. Only required when
+            creating a new NFV instance.
+        required: false
+        type: int
+      memory:
+        description:
+          - The amount of virtual memory (RAM) that the NFV instance
+            will have when it is created. Can be expressed with
+            various units. Only required when creating a new NFV
+            instance.
+        required: false
+        type: str
+      auto_recovery:
+        description:
+          - Whether or not the NFV instance should be restarted on a
+            different host node in the event that its host node
+            fails. Defaults to true.
+        required: false
+        type: bool
+  network_address:
+    description:
+      - The identifying address for the VNET network.
+      - Example - "192.168.0.0" for the 192.168.0.0/24 network.
+    required: False
+    type: str
+  subnet_mask:
+    description:
+      - The subnet mask for the VNET network.
+      - Example - "255.255.255.0" for the 192.168.0.0/24 network.
+    required: False
+    type: str
+  gateway:
+    description:
+      - The IP address for the gateway for this network.
+      - Example - "192.168.0.1"
+    required: False
+    type: str
+  dhcp:
+    description:
+      - The DHCP configuration for the NFV intance.
+      - Required if an NFV instance is being created.
+    required: False
+    type: dict
+    suboptions:
+      dhcp_start:
+        description:
+          - The starting IP address in the DHCP range.
         required: False
         type: str
-    vlan_tag:
+      dhcp_end:
         description:
-            - The VLAN ID to tag the network traffic with.
-            - Must be in the range of 1-4094.
-            - Only valid for VLAN network types.
+          - The ending IP address in the DHCP range.
+        required: False
+        type: str
+      domain_name:
+        description:
+          - The domain name to be used for hosts in the DHCP range.
+        required: False
+        type: str
+      lease_time:
+        description:
+          - The length of the DHCP leases, in seconds.
         required: False
         type: int
-    firewall_override:
+      dns1:
         description:
-            - The name of a firewall override to be assigned to a VNET.
-            - Only valid for VNET network types.
+          - The primary DNS server for the DHCP configuration.
         required: False
         type: str
-    firewall_profile:
+      dns2:
         description:
-            - The name of a firewall profile to be assigned to a VNET.
+          - The secondary DNS server for the DHCP configuration.
         required: False
         type: str
-    autodeploy_nfv:
+      static_bindings:
         description:
-            - Whether the network function virtualization (NFV) instance
-                will be created along with the VNET network.
-            - If this is set to False, the VNET network will need an NFV
-                added manually later before it will work properly.
-            - Only valid for VNET network types.
+          - A list of static DHCP bindings, each binding requires at
+            least an ip_address and mac_address value as a dict.
         required: False
-        type: bool
-    nfv:
-        description:
-            - The settings to create an NFV instance to provide routing and
-                DHCP functionality to the VNET.
-            - Required if autodeploy_nfv is set to true.
-            - Only valid for VNET network types.
-        required: False
-        type: dict
+        type: list
         suboptions:
-            datacenter:
-                description:
-                    - The name of the virtual datacenter that the NFV instance
-                        will be created in. Only required when creating an NFV
-                        instance.
-                required: false
-                type: str
-            storage_pool:
-                description:
-                    - The name of the storage pool that the NFV instance's
-                        disks will be stored in. Only required when creating a
-                        new instance.
-                required: false
-                type: str
-            migration_zone:
-                description:
-                    - The name of the migration zone that the NFV instance will
-                        be created in. Only required when creating a new NFV
-                        instance.
-                required: false
-                type: str
-            cpu_cores:
-                description:
-                    - The number of virtual CPU cores that the NFV instance
-                        will have when it is created. Only required when
-                        creating a new NFV instance.
-                required: false
-                type: int
-            memory:
-                description:
-                    - The amount of virtual memory (RAM) that the NFV instance
-                        will have when it is created. Can be expressed with
-                        various units. Only required when creating a new NFV
-                        instance.
-                required: false
-                type: str
-            auto_recovery:
-                description:
-                    - Whether or not the NFV instance should be restarted on a
-                        different host node in the event that its host node
-                        fails. Defaults to true.
-                required: false
-                type: bool
-    network_address:
+          hostname:
+            description:
+              - A hostname to be assigned to a bound to a
+                particular IP address.
+            required: false
+            type: str
+          ip_address:
+            description:
+              - The IP address to be bound to the hostname
+                and/or MAC address provided in this entry.
+            required: false
+            type: str
+          mac_address:
+            description:
+              - The MAC address to be bound to the IP address
+                provided in this entry.
+            required: false
+            type: str
+  routing:
+    description:
+      - Defines the network settings for the outside interface of the NFV
+        instance.
+    required: False
+    type: dict
+    suboptions:
+      type:
         description:
-            - The identifying address for the VNET network.
-            - Example: "192.168.0.0" for the 192.168.0.0/24 network.
-        required: False
+          - The type of network the outside interface will belong to.
+          - Valid choices are either "VNET" or "VLAN".
+        required: false
         type: str
-    subnet_mask:
+      network:
         description:
-            - The subnet mask for the VNET network.
-            - Example: "255.255.255.0" for the 192.168.0.0/24 network.
-        required: False
+          - The name of the existing network the outside interface
+            will belong to. Must be of the network type specified
+            in the type field.
+        required: false
         type: str
-    gateway:
+      address_mode:
         description:
-            - The IP address for the gateway for this network.
-            - Example: "192.168.0.1"
-        required: False
+          - The mode of setting the outside interface IP address.
+          - Valid choices are either "static" or "DHCP".
+        required: false
         type: str
-    dhcp:
+      ip_address:
         description:
-            - The DHCP configuration for the NFV intance.
-            - Required if an NFV instance is being created.
-        required: False
-        type: dict
-        suboptions:
-            dhcp_start:
-                description:
-                    - The starting IP address in the DHCP range.
-                required: False
-                type: str
-            dhcp_end:
-                description:
-                    - The ending IP address in the DHCP range.
-                required: False
-                type: str
-            domain_name:
-                description:
-                    - The domain name to be used for hosts in the DHCP range.
-                required: False
-                type: str
-            lease_time:
-                description:
-                    - The length of the DHCP leases, in seconds.
-                required: False
-                type: int
-            dns1:
-                description:
-                    - The primary DNS server for the DHCP configuration.
-                required: False
-                type: str
-            dns2:
-                description:
-                    - The secondary DNS server for the DHCP configuration.
-                required: False
-                type: str
-            static_bindings:
-                description:
-                    - A list of static DHCP bindings, each binding requires at
-                        least an ip_address and mac_address value as a dict.
-                required: False
-                type: list
-                suboptions:
-                    hostname:
-                        description:
-                            - A hostname to be assigned to a bound to a
-                                particular IP address.
-                        required: false
-                        type: str
-                    ip_address:
-                        description:
-                            - The IP address to be bound to the hostname
-                                and/or MAC address provided in this entry.
-                        required: false
-                        type: str
-                    mac_address:
-                        description:
-                            - The MAC address to be bound to the IP address
-                                provided in this entry.
-                        required: false
-                        type: str
-    routing:
+          - The IP address of the outside interface.
+          - Only valid when address_mode is set to static.
+        required: false
+        type: str
+      subnet_mask:
         description:
-            - Defines the network settings for the outside interface of the NFV
-                instance.
-        required: False
-        type: dict
-        suboptions:
-            type:
-                description:
-                    - The type of network the outside interface will belong to.
-                    - Valid choices are either "VNET" or "VLAN".
-                required: false
-                type: str
-            network:
-                description:
-                    - The name of the existing network the outside interface
-                        will belong to. Must be of the network type specified
-                        in the type field.
-                required: false
-                type: str
-            address_mode:
-                description:
-                    - The mode of setting the outside interface IP address.
-                    - Valid choices are either "static" or "DHCP".
-                required: false
-                type: str
-            ip_address:
-                description:
-                    - The IP address of the outside interface.
-                    - Only valid when address_mode is set to static.
-                required: false
-                type: str
-            subnet_mask:
-                description:
-                    - The subnet mask of the outside interface.
-                    - Only valid when address_mode is set to static.
-                required: false
-                type: str
-            gateway:
-                description:
-                    - The IP address of the outside interface's gateway.
-                    - Only valid when address_mode is set to static.
-                required: false
-                type: str
+          - The subnet mask of the outside interface.
+          - Only valid when address_mode is set to static.
+        required: false
+        type: str
+      gateway:
+        description:
+          - The IP address of the outside interface's gateway.
+          - Only valid when address_mode is set to static.
+        required: false
+        type: str
+
 '''
 
 EXAMPLES = '''
@@ -365,11 +366,11 @@ EXAMPLES = '''
 
 RETURN = '''
 msg:
-    description:
-        - An error message in the event of invalid input or other
-        unexpected behavior during module execution.
-    type: str
-    returned: failure
+  description:
+    - An error message in the event of invalid input or other
+      unexpected behavior during module execution.
+  type: str
+  returned: failure
 '''
 
 
@@ -692,7 +693,8 @@ def run_module():
             vnet_uuid = vnet_resource.get_uuid_by_name(name)
 
             if vnet_uuid:
-                nfv_uuid = vnet_resource.get_by_uuid(vnet_uuid).to_dict()['nfv_instance_uuid']
+                nfv_uuid = vnet_resource.get_by_uuid(vnet_uuid).to_dict()[
+                    'nfv_instance_uuid']
 
                 if nfv_uuid:
                     # Delete the NFV instance

--- a/lib/ansible/modules/tacp/tacp_network.py
+++ b/lib/ansible/modules/tacp/tacp_network.py
@@ -23,28 +23,256 @@ DOCUMENTATION = '''
 ---
 module: tacp_network
 
-short_description: This is my test module
-
-version_added: "2.9"
+short_description: Creates and deletes VLAN and VNET networks on ThinkAgile CP.
 
 description:
-    - "This is my longer description explaining my test module"
-
-options:
-    name:
-        description:
-            - This is the message to send to the test module
-        required: true
-    new:
-        description:
-            - Control to demo if the result of this module is changed or not
-        required: false
-
-extends_documentation_fragment:
-    - tacp
+    - 'This module can be used to create new VLAN and VNET networks on the
+        ThinkAgile CP cloud platform, as well as delete existing networks.'
+    - 'Currently this module cannot modify the settings of existing
+        networks; all settings must be specified at creation time.'
 
 author:
+    - Lenovo (@lenovo)
     - Xander Madsen (@xmadsen)
+
+requirements:
+- tacp
+
+options:
+    api_key:
+        description:
+            - An API key generated in the Developer Options in the ThinkAgile
+                CP portal. This is required to perform any operations with this
+                module.
+        required: true
+        type: str
+    name:
+        description:
+            - This is the name of the network to be created or deleted.
+        required: true
+        type: str
+    state:
+        description:
+            - The desired state for the network. 
+            - Only valid for VLAN networks.
+        required: false
+        default: present
+        type: str
+    network_type:
+        description:
+            - The type of network. Valid choices are either "VNET" or "VLAN".
+        required: True
+        type: str
+    site_name:
+        description: 
+            - The name of the site that the network will be a part of.
+            - If only one site exists, that site will be used by default and
+                this parameter is unneeded.
+        required: False
+        type: str
+    vlan_tag:
+        description:
+            - The VLAN ID to tag the network traffic with.
+            - Must be in the range of 1-4094.
+            - Only valid for VLAN network types.
+        required: False
+        type: int
+    firewall_override:
+        description:
+            - The name of a firewall override to be assigned to a VNET.
+            - Only valid for VNET network types.
+        required: False
+        type: str
+    firewall_profile:
+        description:
+            - The name of a firewall profile to be assigned to a VNET.
+        required: False
+        type: str
+    autodeploy_nfv:
+        description:
+            - Whether the network function virtualization (NFV) instance
+                will be create along with the VNET network.
+            - If this is set to False, the VNET network will need an NFV
+                added manually later before it will work properly.
+            - Only valid for VNET network types.
+        required: False
+        type: bool
+    nfv:
+        description:
+            - The settings to create an NFV instance to provide routing and
+                DHCP functionality to the VNET.
+            - Required if autodeploy_nfv is set to true.
+            - Only valid for VNET network types.
+        required: False
+        type: dict
+        suboptions:
+            datacenter:
+                description:
+                    - The name of the virtual datacenter that the NFV instance
+                        will be created in. Only required when creating an NFV
+                        instance.
+                required: false
+                type: str
+            storage_pool:
+                description:
+                    - The name of the storage pool that the NFV instance's
+                        disks will be stored in. Only required when creating a
+                        new instance.
+                required: false
+                type: str
+            migration_zone:
+                description:
+                    - The name of the migration zone that the NFV instance will
+                        be created in. Only required when creating a new NFV
+                        instance.
+                required: false
+                type: str
+            cpu_cores:
+                description:
+                    - The number of virtual CPU cores that the NFV instance
+                        will have when it is created. Only required when
+                        creating a new NFV instance.
+                required: false
+                type: int
+            memory:
+                description:
+                    - The amount of virtual memory (RAM) that the NFV instance
+                        will have when it is created. Can be expressed with
+                        various units. Only required when creating a new NFV
+                        instance.
+                required: false
+                type: str
+            auto_recovery:
+                description:
+                    - Whether or not the NFV instance should be restarted on a
+                        different host node in the event that its host node
+                        fails. Defaults to true.
+                required: false
+                type: bool
+    network_address:
+        description:
+            - The identifying address for the VNET network.
+            - Example: "192.168.0.0" for the 192.168.0.0/24 network.
+        required: False
+        type: str
+    subnet_mask:
+        description:
+            - The subnet mask for the VNET network.
+            - Example: "255.255.255.0" for the 192.168.0.0/24 network.
+        required: False
+        type: str
+    gateway:
+        description:
+            - The IP address for the gateway for this network.
+            - Example: "192.168.0.1"
+        required: False
+        type: str
+    dhcp:
+        description:
+            - The DHCP configuration for the NFV intance.
+            - Required if an NFV instance is being created.
+        required: False
+        type: dict
+        suboptions:
+            dhcp_start:
+                description:
+                    - The starting IP address in the DHCP range.
+                required: False
+                type: str
+            dhcp_end:
+                description:
+                    - The ending IP address in the DHCP range.
+                required: False
+                type: str
+            domain_name:
+                description:
+                    - The domain name to be used for hosts in the DHCP range.
+                required: False
+                type: str
+            lease_time:
+                description:
+                    - The length of the DHCP leases, in seconds.
+                required: False
+                type: int
+            dns1:
+                description:
+                    - The primary DNS server for the DHCP configuration.
+                required: False
+                type: str
+            dns2:
+                description:
+                    - The secondary DNS server for the DHCP configuration.
+                required: False
+                type: str
+            static_bindings:
+                description:
+                    - A list of static DHCP bindings, each binding requires at least
+                        an ip_address and mac_address value as a dict.
+                required: False
+                type: list
+                suboptions:
+                    hostname:
+                        description:
+                            - A hostname to be assigned to a bound to a
+                                particular IP address.
+                        required: false
+                        type: str
+                    ip_address:
+                        description:
+                            - The IP address to be bound to the hostname
+                                and/or MAC address provided in this entry.
+                        required: false
+                        type: str
+                    mac_address:
+                        description:
+                            - The MAC address to be bound to the IP address
+                                provided in this entry.
+                        required: false
+                        type: str
+    routing:
+        description:
+            - Defines the network settings for the outside interface of the NFV
+                instance.
+        required: False
+        type: dict
+        suboptions:
+            type:
+                description:
+                    - The type of network the outside interface will belong to.
+                    - Valid choices are either "VNET" or "VLAN".
+                required: false
+                type: str
+            network:
+                description:
+                    - The name of the existing network the outside interface
+                        will belong to. Must be of the network type specified
+                        in the type field.
+                required: false
+                type: str
+            address_mode:
+                description:
+                    - The mode of setting the outside interface IP address.
+                    - Valid choices are either "static" or "DHCP".
+                required: false
+                type: str
+            ip_address:
+                description:
+                    - The IP address of the outside interface.
+                    - Only valid when address_mode is set to static.
+                required: false
+                type: str
+            subnet_mask:
+                description:
+                    - The subnet mask of the outside interface.
+                    - Only valid when address_mode is set to static.
+                required: false
+                type: str
+            gateway:
+                description:
+                    - The IP address of the outside interface's gateway.
+                    - Only valid when address_mode is set to static.
+                required: false
+                type: str
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
This PR adds in-module documentation to be eventually added to the Ansible documentation site when these modules are submitted to Ansible Core, as well as a README with installation instructions for incorporating the tacp modules from this fork into a user's local Ansible installation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
tacp_instance
tacp_network
tacp_info