### PR TITLE
Fix KeyError bug in tacp_info due to filters() parsing issue

### DIFF
--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -134,7 +134,7 @@ class Resource(object):
             else:
                 op = '=='
                 value = v
-            filters.append('{}{}"{}"'.format(k, op, value))
+            filters.append('{}{}{}'.format(k, op, value))
 
         return ';'.join(filters)
 


### PR DESCRIPTION
fixes the bug in tacp_info but causes
an issue in other modules when using text with a space

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
