### PR TITLE
OL-11393 Put values in quotes before appending to filters string

### DIFF
--- a/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
+++ b/lib/ansible/module_utils/tacp_ansible/tacp_utils.py
@@ -129,12 +129,12 @@ class Resource(object):
 
                 value = value[0]
                 if op in ('=in=', '=out='):
-                    value = ','.join(map(str, value))
+                    value = ','.join(map(lambda v: '"{}"'.format(v), value))
                     value = '({})'.format(value)
             else:
                 op = '=='
-                value = v
-            filters.append('{}{}"{}"'.format(k, op, value))
+                value = '"{}"'.format(v)
+            filters.append('{}{}{}'.format(k, op, value))
 
         return ';'.join(filters)
 

--- a/lib/ansible/modules/tacp/tacp_info.py
+++ b/lib/ansible/modules/tacp/tacp_info.py
@@ -10,7 +10,7 @@ from ansible.module_utils.tacp_ansible.tacp_exceptions import UuidNotFoundExcept
 
 import tacp
 from tacp.rest import ApiException
-
+import sys
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -202,6 +202,7 @@ def run_module():
                                     vlan_resource.filter(uuid=('=in=', uuids))}  # noqa
                 network_list.update({vnet.uuid: vnet.name for vnet in
                                     vnet_resource.filter(uuid=('=in=', uuids))})  # noqa
+
                 for network in item['networks']:
                     network['name'] = network_list[network['uuid']]
 

--- a/lib/ansible/modules/tacp/tacp_info.py
+++ b/lib/ansible/modules/tacp/tacp_info.py
@@ -10,7 +10,6 @@ from ansible.module_utils.tacp_ansible.tacp_exceptions import UuidNotFoundExcept
 
 import tacp
 from tacp.rest import ApiException
-import sys
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes filters() method encountering issues in HTTP request formatting when spaces are present in the values provided. The change puts quotes around all values, including individual elements in lists.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tacp_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
